### PR TITLE
Python bridge module

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ call.enqueue(new Callback<Terms>() {
 ```
 
 ## Usage from Python.
-This is an experimental feature.  See [python-bridge](tree/master/python-bridge) for details.
+This is an experimental feature.  See [python-bridge](python-bridge) for details.
 
 ## Contributing
 TODO - Project setup, etc

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 
 The SDK is broken up into 3 libraries:
 
-| Component | Description                      |
-|-----------|----------------------------------|
-| core      | Core objects.  Required.         |
-| auth      | TODO.                            |
-| api       | API requests.                    |
-| android   | Android-specific objects.        |
+| Component     | Description                        |
+|---------------|------------------------------------| 
+| core          | Core objects.  Required.           |
+| auth          | TODO.                              |
+| api           | API requests.                      |
+| android       | Android-specific objects.          |
+| python-bridge | Allows core/api usage from python. |
    
 
 ### Using Gradle / Maven
@@ -76,6 +77,9 @@ call.enqueue(new Callback<Terms>() {
     public void onFailure(Call<Terms> call, Throwable t) { }    
 });
 ```
+
+## Usage from Python.
+This is an experimental feature.  See [python-bridge](tree/master/python-bridge) for details.
 
 ## Contributing
 TODO - Project setup, etc

--- a/python-bridge/README.md
+++ b/python-bridge/README.md
@@ -1,0 +1,52 @@
+# Python Bridge
+
+**This is an experimental feature**
+
+Using [py4j](https://www.py4j.org/) you can use the core/api libraries from python.
+
+First, you must run `PercolateSdkPythonBridge.java` to start the java bridge required by py4j.
+
+```
+java PercolateSdkPythonBridge
+>Python Bridge Running.  Ctrl+C to stop.
+```
+
+Here is an example request to get a `Post` object.  See the [py4j docs](https://www.py4j.org/contents.html) for details.
+
+```python
+#!/usr/bin/python
+from py4j.java_gateway import (
+    JavaGateway,
+    GatewayParameters,
+    java_import
+)
+
+API_KEY = "--your-api-key--"
+
+gateway = JavaGateway(gateway_parameters=GatewayParameters(auto_convert=True))
+api = gateway.jvm
+java_import(api, 'com.percolate.sdk.api.PercolateApi')
+java_import(api, 'com.percolate.sdk.api.request.post.PostGetParams')
+
+percolate_api = api.PercolateApi(API_KEY)
+percolate_api.getSelectedServer().setEnableLocalProxy(True);
+
+params = api.PostGetParams("post:--your-post-id--")\
+  .scopeIds(["license:--your-license-id--"])
+
+post = percolate_api\
+  .post()\
+  .get(params)\
+  .execute()\
+  .body();
+
+print post
+print "-" * 30
+print "ID: %s" % post.getData().getId()
+print "Name: %s" % post.getData().getName()
+print "User: %s" % post.getData().getUserId()
+print "Platform: %s" % post.getData().getPlatformId()
+print "Channel: %s" % post.getData().getChannelId()
+print "Schema: %s" % post.getData().getSchemaId()
+print "User: %s" % post.getData().getUserId()
+```

--- a/python-bridge/build.gradle
+++ b/python-bridge/build.gradle
@@ -1,0 +1,73 @@
+apply plugin: 'java'
+apply plugin: 'kotlin'
+apply plugin: 'maven'
+apply plugin: 'jacoco'
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+group 'com.percolate.sdk'
+version '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task skipWarningsJavaDoc(type: Javadoc) {
+    options.addStringOption("Xdoclint:none")
+}
+
+task javadocJar(type: Jar, dependsOn: skipWarningsJavaDoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+tasks.withType(Javadoc) {
+    options.addStringOption('-Xdoclint:none')
+}
+
+task coverage(dependsOn: jacocoTestReport) {
+    group = "Reporting"
+    description = 'Create code coverage report for python-bridge module'
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        xml.destination "${buildDir}/jacocoPythonBridgeTests.xml"
+    }
+}
+
+dependencies {
+    compile project(':api')
+
+    testCompile 'junit:junit:4.12'
+
+    // Py4j python to java bridge
+    compile 'net.sf.py4j:py4j:0.9.1'
+
+    // Apache Commons
+    compile 'org.apache.commons:commons-lang3:3.4'
+
+    // Jackson
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.1'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.7.1'
+    compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.1'
+
+    // JetBrains Annotations
+    compile 'org.jetbrains:annotations-java5:15.0'
+
+    // Retrofit
+    compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
+    compile 'com.squareup.retrofit2:converter-jackson:2.0.0-beta4'
+}

--- a/python-bridge/src/main/java/com/percoalte/sdk/python/bridge/PercolateSdkPythonBridge.java
+++ b/python-bridge/src/main/java/com/percoalte/sdk/python/bridge/PercolateSdkPythonBridge.java
@@ -1,0 +1,16 @@
+package com.percoalte.sdk.python.bridge;
+
+import py4j.GatewayServer;
+
+/**
+ * Py4j java bridge.  See module README for details and usage.
+ */
+public class PercolateSdkPythonBridge {
+
+    public static void main(String[] args) {
+        PercolateSdkPythonBridge app = new PercolateSdkPythonBridge();
+        GatewayServer server = new GatewayServer(app);
+        System.out.println("Python Bridge Running.  Ctrl+C to stop.");
+        server.start();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
-include ':core', ':android', ':api'
-
+include ':core', ':android', ':api', ':python-bridge'


### PR DESCRIPTION
- 4th module added to this project: `python-bridge`.
- Uses [py4j](py4j.org) to allow usage of the percolate java sdk from python code.
- See python-bridge/README.md for details and example usage.
