### PR TITLE
Added @JsonIgnore to extraFields

### DIFF
--- a/core/src/main/java/com/percolate/sdk/dto/ActivityStream.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ActivityStream.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class ActivityStream implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<ActivityStreamData> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ActivityStreamData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ActivityStreamData.java
@@ -55,6 +55,7 @@ public class ActivityStreamData implements Serializable, HasExtraFields {
     @JsonProperty("mentions")
     protected List<Mention> mentions;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ActivityStreamMetadata.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ActivityStreamMetadata.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class ActivityStreamMetadata implements Serializable, HasExtraFields {
     @JsonProperty("key")
     protected String key;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ApprovalPool.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ApprovalPool.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -33,6 +34,7 @@ public class ApprovalPool implements Serializable, HasExtraFields {
     @JsonProperty("steps")
     protected List<ApprovalPoolStep> steps;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ApprovalPoolStep.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ApprovalPoolStep.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -33,6 +34,7 @@ public class ApprovalPoolStep implements Serializable, HasExtraFields {
     @JsonProperty("ordinal")
     protected Integer ordinal;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ApprovalPools.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ApprovalPools.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class ApprovalPools implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<ApprovalPool> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/AuthTokenData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthTokenData.java
@@ -1,9 +1,9 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -39,6 +39,7 @@ public class AuthTokenData implements Serializable, HasExtraFields {
     @JsonProperty("expires_at")
     protected String expiresAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/AuthorizeData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthorizeData.java
@@ -1,9 +1,9 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -33,6 +33,7 @@ public class AuthorizeData implements Serializable, HasExtraFields {
     @JsonProperty("updated_at")
     private String updatedAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/AuthorizeDataExt.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthorizeDataExt.java
@@ -1,9 +1,9 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -27,6 +27,7 @@ public class AuthorizeDataExt implements Serializable, HasExtraFields {
     @JsonProperty("callback_url")
     protected String callbackUrl;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/AuthorizePostData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthorizePostData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -35,6 +36,7 @@ public class AuthorizePostData implements Serializable, HasExtraFields {
     @JsonProperty("ext")
     protected AuthorizePostDataExt ext;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/AuthorizePostDataExt.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthorizePostDataExt.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class AuthorizePostDataExt implements Serializable, HasExtraFields {
     @JsonProperty("client_id")
     protected String clientId;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Autocomplete.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Autocomplete.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -40,6 +41,7 @@ public class Autocomplete implements Serializable, HasExtraFields {
     @JsonProperty("college_years")
     protected List<LinkedHashMap<String, Object>> collegeYears;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Brand.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Brand.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class Brand implements Serializable, HasExtraFields {
     @JsonProperty("name")
     protected String name;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Brew.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Brew.java
@@ -2,6 +2,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -36,6 +37,7 @@ public class Brew implements Serializable, HasExtraFields {
     @JsonProperty("approved")
     protected boolean approved;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/BrewLicenceConnection.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewLicenceConnection.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -44,6 +45,7 @@ public class BrewLicenceConnection implements Serializable, HasExtraFields {
     @JsonProperty("order")
     protected Integer order;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/BrewLinkData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewLinkData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -56,6 +57,7 @@ public class BrewLinkData implements Serializable, HasExtraFields {
     @JsonProperty("created_at")
     protected String createdAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/BrewLinks.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewLinks.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class BrewLinks implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData pagination;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/BrewUsers.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewUsers.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class BrewUsers implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<User> users = new ArrayList<>();
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/BrewsForLicense.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewsForLicense.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class BrewsForLicense implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<BrewLicenceConnection> data = new ArrayList<>();
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Brief.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Brief.java
@@ -101,6 +101,7 @@ public class Brief implements Serializable, HasExtraFields {
     @JsonProperty("comment_count")
     protected Integer commentCount;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/BriefData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BriefData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class BriefData implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected Brief brief;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Briefs.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Briefs.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class Briefs implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/CampaignSectionData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CampaignSectionData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -30,6 +31,7 @@ public class CampaignSectionData implements Serializable, HasExtraFields {
     @JsonProperty("media_uids")
     protected List<String> mediaUids;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/CannedResponseData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CannedResponseData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -42,6 +43,7 @@ public class CannedResponseData implements Serializable, HasExtraFields {
     @JsonProperty("updated_at")
     protected String updatedAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/CannedResponses.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CannedResponses.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class CannedResponses implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<CannedResponseData> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/CannedResponsesMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CannedResponsesMetaData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class CannedResponsesMetaData implements Serializable, HasExtraFields {
     @JsonProperty("total")
     protected Long total;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ChangePasswordError.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ChangePasswordError.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -30,6 +31,7 @@ public class ChangePasswordError implements Serializable, HasExtraFields {
         this.errors = errors;
     }
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Channel.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Channel.java
@@ -42,6 +42,7 @@ public class Channel implements Serializable, HasExtraFields {
     @JsonProperty("page_id")
     protected String pageId;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ChannelV5.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ChannelV5.java
@@ -73,6 +73,7 @@ public class ChannelV5 implements Serializable, HasExtraFields {
     @JsonProperty("ext")
     protected Object ext;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Channels.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Channels.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class Channels implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<ChannelV5> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Comment.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Comment.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -47,6 +48,7 @@ public class Comment implements Serializable, HasExtraFields {
     @JsonProperty("updated_at")
     protected String updatedAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/CommentContextExt.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CommentContextExt.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class CommentContextExt implements Serializable, HasExtraFields {
     @JsonProperty("unit")
     protected String unit;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/CommentData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CommentData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class CommentData implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected Comment comment;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Comments.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Comments.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class Comments implements Serializable, HasExtraFields {
     @JsonProperty("include")
     protected CommentsInclude include;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/CommentsInclude.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CommentsInclude.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class CommentsInclude implements Serializable, HasExtraFields {
     @JsonProperty("user")
     protected List<User> users;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Creator.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Creator.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class Creator implements Serializable, HasExtraFields {
     @JsonProperty("brand_id")
     protected Long brandId;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/CurrencyValue.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CurrencyValue.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class CurrencyValue implements Serializable, HasExtraFields {
     @JsonProperty("amount")
     protected String amount;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/DateRangeValue.java
+++ b/core/src/main/java/com/percolate/sdk/dto/DateRangeValue.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class DateRangeValue implements Serializable, HasExtraFields {
     @JsonProperty("to")
     protected String to;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/EnabledProperty.java
+++ b/core/src/main/java/com/percolate/sdk/dto/EnabledProperty.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -25,6 +26,7 @@ public class EnabledProperty implements Serializable, HasExtraFields {
         this.enabled = enabled;
     }
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Entry.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Entry.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -30,6 +31,7 @@ public class Entry implements Serializable, HasExtraFields {
     @JsonProperty("url")
     protected String url;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Error.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Error.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class Error implements Serializable, HasExtraFields {
     @JsonProperty("code")
     protected String code;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Errors.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Errors.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class Errors implements Serializable, HasExtraFields {
     @JsonProperty("errors")
     protected List<Error> errors;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationList.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class FacebookConversationList implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationListData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationListData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -76,6 +77,7 @@ public class FacebookConversationListData implements Serializable, HasExtraField
                 .toHashCode();
     }
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessage.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessage.java
@@ -56,6 +56,7 @@ public class FacebookConversationMessage implements Serializable, HasExtraFields
     @JsonProperty("message")
     protected String message;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessageId.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessageId.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class FacebookConversationMessageId implements Serializable, HasExtraFiel
     @JsonProperty("message_id")
     protected String messageId;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessageIdData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessageIdData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class FacebookConversationMessageIdData implements Serializable, HasExtra
     @JsonProperty("data")
     protected FacebookConversationMessageId data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationThread.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationThread.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class FacebookConversationThread implements Serializable, HasExtraFields 
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMention.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMention.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class FacebookMention implements Serializable, HasExtraFields {
     @JsonProperty("picture")
     protected FacebookMentionPicture picture;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMentionData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMentionData.java
@@ -30,6 +30,7 @@ public class FacebookMentionData implements Serializable, HasExtraFields, Compar
     @JsonProperty("offset")
     protected Integer offset;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMentionPicture.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMentionPicture.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -19,6 +20,7 @@ public class FacebookMentionPicture implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected FacebookMentionPictureData data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMentionPictureData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMentionPictureData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -22,6 +23,7 @@ public class FacebookMentionPictureData implements Serializable, HasExtraFields 
     @JsonProperty("is_silhouette")
     protected boolean silhouette;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMentions.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMentions.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class FacebookMentions implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<FacebookMention> mentions;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachment.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachment.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -29,6 +30,7 @@ public class FacebookMessageAttachment implements Serializable, HasExtraFields {
     @JsonProperty("image_data")
     protected FacebookMessageAttachmentImageData imageData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachmentImageData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachmentImageData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -41,6 +42,7 @@ public class FacebookMessageAttachmentImageData implements Serializable, HasExtr
     @JsonProperty("image_type")
     protected Integer imageType;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachments.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachments.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class FacebookMessageAttachments implements Serializable, HasExtraFields 
     @JsonProperty("data")
     protected List<FacebookMessageAttachment> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageExtendedData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageExtendedData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -41,6 +42,7 @@ public class FacebookMessageExtendedData implements Serializable, HasExtraFields
     @JsonProperty("attachments")
     protected FacebookMessageAttachments attachments;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageKeyValueList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageKeyValueList.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -22,6 +23,7 @@ public class FacebookMessageKeyValueList implements Serializable, HasExtraFields
     @JsonProperty("data")
     protected List<LinkedHashMap<String, Object>> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObject.java
@@ -38,6 +38,7 @@ public class FacebookMonitoringObject implements Serializable, HasExtraFields {
     @JsonProperty("xobj")
     protected FacebookMonitoringXObj xobj;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObjects.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObjects.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class FacebookMonitoringObjects implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringUser.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class FacebookMonitoringUser implements Serializable, HasExtraFields {
     @JsonProperty("name")
     protected String name;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringXObj.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringXObj.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -53,6 +54,7 @@ public class FacebookMonitoringXObj implements Serializable, HasExtraFields {
     @JsonProperty("user")
     protected FacebookMonitoringUser user;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookUser.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -49,6 +50,7 @@ public class FacebookUser implements Serializable, HasExtraFields {
     @JsonProperty("hometown")
     protected LinkedHashMap<String, String> hometown;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookUserDataList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookUserDataList.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class FacebookUserDataList implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<FacebookUser> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Facets.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Facets.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class Facets implements Serializable, HasExtraFields {
     @JsonProperty("tags")
     protected LinkedHashMap<String, Integer> tags = new LinkedHashMap<>();
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FeatureData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FeatureData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -32,6 +33,7 @@ public class FeatureData implements Serializable, HasExtraFields {
     @JsonProperty("value")
     protected Object value;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Features.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Features.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class Features implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<FeatureData> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Flag.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Flag.java
@@ -103,6 +103,7 @@ public class Flag implements Serializable, HasExtraFields {
     @JsonProperty("status_type")
     protected String statusType; //Should match one of FlaggingStatusType enums.
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/FlagOwner.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FlagOwner.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class FlagOwner implements Serializable, HasExtraFields {
     @JsonProperty("license")
     protected License license;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Flags.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Flags.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class Flags implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Follower.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Follower.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -32,6 +33,7 @@ public class Follower implements Serializable, HasExtraFields {
     @JsonProperty("error_id")
     protected String errorId;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Followers.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Followers.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class Followers implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<Follower> followers;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ImageLicense.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ImageLicense.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class ImageLicense implements Serializable, HasExtraFields {
     @JsonProperty("owner_url")
     protected String owner_url;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ImageSize.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ImageSize.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -35,6 +36,7 @@ public class ImageSize implements Serializable, HasExtraFields {
     @JsonProperty("height")
     protected String height;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramComment.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramComment.java
@@ -35,6 +35,7 @@ public class InstagramComment implements Serializable, HasExtraFields {
     @JsonProperty("created_time")
     protected String createdTime;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramComments.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramComments.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class InstagramComments implements Serializable, HasExtraFields {
     @JsonProperty("count")
     protected Long count;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramImageLocation.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramImageLocation.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -29,6 +30,7 @@ public class InstagramImageLocation implements Serializable, HasExtraFields {
     @JsonProperty("longitude")
     protected Double longitude;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramIncludeMediaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramIncludeMediaData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -33,6 +34,7 @@ public class InstagramIncludeMediaData implements Serializable, HasExtraFields {
     @JsonProperty("meta")
     protected InstagramMonitoringObjectMetaData meta;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramIncludes.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramIncludes.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class InstagramIncludes implements Serializable, HasExtraFields {
     @JsonProperty("instagram:post")
     protected List<InstagramIncludeMediaData> posts;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramLikes.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramLikes.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class InstagramLikes implements Serializable, HasExtraFields {
     @JsonProperty("count")
     protected Long count;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMedia.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMedia.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class InstagramMedia implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected InstagramMediaData data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMediaComments.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMediaComments.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class InstagramMediaComments implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<InstagramComment> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMediaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMediaData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -66,6 +67,7 @@ public class InstagramMediaData implements Serializable, HasExtraFields {
     @JsonProperty("created_time")
     protected String createdTime;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMediaUrl.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMediaUrl.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class InstagramMediaUrl implements Serializable, HasExtraFields {
     @JsonProperty("height")
     protected int height;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMediaUrls.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMediaUrls.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class InstagramMediaUrls implements Serializable, HasExtraFields {
     @JsonProperty("low_bandwidth")
     protected InstagramMediaUrl lowBandwidth;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObject.java
@@ -40,6 +40,7 @@ public class InstagramMonitoringObject implements Serializable, HasExtraFields {
     @JsonProperty("activity")
     protected List<Object> activity;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObjectMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObjectMetaData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -29,6 +30,7 @@ public class InstagramMonitoringObjectMetaData implements Serializable, HasExtra
     @JsonProperty("parent_shortcode")
     protected String parentShortcode;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObjects.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObjects.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -27,6 +28,7 @@ public class InstagramMonitoringObjects implements Serializable, HasExtraFields 
     @JsonProperty("include")
     protected InstagramIncludes includes;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramPhotoPosition.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramPhotoPosition.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class InstagramPhotoPosition implements Serializable, HasExtraFields {
     @JsonProperty("y")
     protected Double y;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramRecentMedia.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramRecentMedia.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class InstagramRecentMedia implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<InstagramMediaData> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramRequestMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramRequestMetaData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class InstagramRequestMetaData implements Serializable, HasExtraFields {
     @JsonProperty("code")
     protected Integer code;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramSingleMonitoringObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramSingleMonitoringObject.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class InstagramSingleMonitoringObject implements Serializable, HasExtraFi
     @JsonProperty("data")
     protected InstagramMonitoringObject data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramUser.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class InstagramUser implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected InstagramUserData data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramUserCounts.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramUserCounts.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class InstagramUserCounts implements Serializable, HasExtraFields {
     @JsonProperty("media")
     protected Long media;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramUserData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramUserData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -38,6 +39,7 @@ public class InstagramUserData implements Serializable, HasExtraFields {
     @JsonProperty("counts")
     protected InstagramUserCounts counts;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramUsersInPhoto.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramUsersInPhoto.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class InstagramUsersInPhoto implements Serializable, HasExtraFields {
     @JsonProperty("position")
     protected InstagramPhotoPosition position;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InteractionData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InteractionData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -42,6 +43,7 @@ public class InteractionData implements Serializable, HasExtraFields {
     @JsonProperty("updated_at")
     protected String updatedAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Interactions.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Interactions.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class Interactions implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<InteractionData> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InteractionsMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InteractionsMetaData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class InteractionsMetaData implements Serializable, HasExtraFields {
     @JsonProperty("total")
     protected Long total;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/InteractionsMetaDataQuery.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InteractionsMetaDataQuery.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class InteractionsMetaDataQuery implements Serializable, HasExtraFields {
     @JsonProperty("scope_ids")
     protected String scopeIds;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Keywords.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Keywords.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class Keywords implements Serializable, HasExtraFields {
     @JsonProperty("total_occurences")
     protected Integer totalOccurences;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/License.java
+++ b/core/src/main/java/com/percolate/sdk/dto/License.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -58,6 +59,7 @@ public class License implements Serializable, HasExtraFields, Comparable<License
 
     protected List<UserRolesLicenseData> userRolesLicenseData; //Set in some apps after calling ApiGetUserRoles
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/LicenseChannel.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicenseChannel.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -61,6 +62,7 @@ public class LicenseChannel implements Serializable, HasExtraFields {
     @JsonProperty("scoped_channel_uid")
     protected String scopedChannelUid;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/LicenseChannels.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicenseChannels.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class LicenseChannels implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/LicensePublishingSettings.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicensePublishingSettings.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -36,6 +37,7 @@ public class LicensePublishingSettings implements Serializable, HasExtraFields {
     @JsonProperty("tags")
     protected List<Topic> topics;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/LicenseUserInfo.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicenseUserInfo.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -65,6 +66,7 @@ public class LicenseUserInfo implements Serializable, HasExtraFields {
                 .toHashCode();
     }
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/LicenseUsers.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicenseUsers.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class LicenseUsers implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Licenses.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Licenses.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class Licenses implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<License> licenses = new ArrayList<>();
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Link.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Link.java
@@ -40,6 +40,7 @@ public class Link implements Serializable, HasExtraFields {
     @JsonProperty("medias")
     protected List<Media> medias = new ArrayList<>();
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/LocalCreatedAt.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LocalCreatedAt.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class LocalCreatedAt implements Serializable, HasExtraFields {
     @JsonProperty("timezone")
     protected String timezone;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Media.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Media.java
@@ -70,6 +70,7 @@ public class Media implements Serializable, HasExtraFields {
     @JsonIgnore
     protected ArrayList<ImageSize> imagesForTypeVideo;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/MediaFormat.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaFormat.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -32,6 +33,7 @@ public class MediaFormat implements Serializable, HasExtraFields {
     @JsonProperty("file_size")
     protected String fileSize;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/MediaList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaList.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -31,6 +32,7 @@ public class MediaList implements Serializable, HasExtraFields {
     @JsonProperty("errors")
     protected List<LinkedHashMap<String, Object>> errors;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/MediaMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaMetaData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -83,6 +84,7 @@ public class MediaMetaData implements Serializable, HasExtraFields {
     @JsonProperty("path")
     protected List<String> path;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/MediaMetaDataHolder.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaMetaDataHolder.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class MediaMetaDataHolder implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected MediaMetaData data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/MediaReleaseResponse.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaReleaseResponse.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class MediaReleaseResponse implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected MediaReleaseResponseData data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/MediaReleaseResponseData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaReleaseResponseData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -44,6 +45,7 @@ public class MediaReleaseResponseData implements Serializable, HasExtraFields {
     @JsonProperty("signature_image_url")
     protected String signatureImageUrl;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Mention.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Mention.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class Mention implements Serializable, HasExtraFields {
     @JsonProperty("length")
     protected Integer length;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/MobileAppPushToken.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MobileAppPushToken.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class MobileAppPushToken implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected MobileAppPushTokenData mobileAppPushTokenData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/MobileAppPushTokenData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MobileAppPushTokenData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -41,6 +42,7 @@ public class MobileAppPushTokenData implements Serializable, HasExtraFields {
     @JsonProperty("mobile_app_arn")
     protected String mobileAppArn;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/MobileVersionCheck.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MobileVersionCheck.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -44,6 +45,7 @@ public class MobileVersionCheck implements Serializable, HasExtraFields {
     @JsonProperty("error")
     protected String error;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/OAuthToken.java
+++ b/core/src/main/java/com/percolate/sdk/dto/OAuthToken.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class OAuthToken implements Serializable, HasExtraFields {
     @JsonProperty("data")
     public OAuthTokenData oAuthTokenData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/OAuthTokenData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/OAuthTokenData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class OAuthTokenData implements Serializable, HasExtraFields {
     @JsonProperty("scope_id")
     protected String scopeUID;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/OwnedChannel.java
+++ b/core/src/main/java/com/percolate/sdk/dto/OwnedChannel.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -47,6 +48,7 @@ public class OwnedChannel implements Serializable, HasExtraFields {
     @JsonProperty("photo_url")
     protected String photoUrl;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Owner.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Owner.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class Owner implements Serializable, HasExtraFields {
     @JsonProperty("license")
     protected License license;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/PaginationData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PaginationData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -56,6 +57,7 @@ public class PaginationData implements Serializable, HasExtraFields {
         }
     }
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Platform.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Platform.java
@@ -52,6 +52,7 @@ public class Platform implements Serializable, HasExtraFields, Comparable<Platfo
     @JsonProperty("updated_at")
     protected String updatedAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Platforms.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Platforms.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class Platforms implements Serializable, HasExtraFields {
     @JsonProperty("data")
     public List<Platform> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Plug.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Plug.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -35,6 +36,7 @@ public class Plug implements Serializable, HasExtraFields {
     @JsonProperty("end_at")
     protected String endAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Plugs.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Plugs.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -22,6 +23,7 @@ public class Plugs implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<Plug> plugs = new ArrayList<>();
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Post.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Post.java
@@ -109,6 +109,7 @@ public class Post implements Serializable, HasExtraFields {
     @JsonProperty("facebook_mentions")
     protected List<FacebookMentionData> facebookMentions;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/PostSet.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostSet.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class PostSet implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/PostSetData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostSetData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -106,6 +107,7 @@ public class PostSetData implements Serializable, HasExtraFields {
     @JsonProperty("errors")
     protected List<LinkedHashMap<String, Object>> errors;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/PostV5.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostV5.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -28,6 +29,7 @@ public class PostV5 implements Serializable, HasExtraFields {
     @JsonProperty("errors")
     protected List<LinkedHashMap<String, Object>> errors;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/PostV5Data.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostV5Data.java
@@ -117,6 +117,7 @@ public class PostV5Data implements Serializable, HasExtraFields {
     @JsonProperty("ext")
     protected LinkedHashMap<String, Object> ext;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/PostV5Include.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostV5Include.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class PostV5Include implements Serializable, HasExtraFields {
     @JsonProperty("channel")
     protected List<ChannelV5> channel;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/PostsV5.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostsV5.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -27,6 +28,7 @@ public class PostsV5 implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<PostV5Data> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Publishing.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Publishing.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -38,6 +39,7 @@ public class Publishing implements Serializable, HasExtraFields {
     @JsonProperty("album_xid")
     protected Object albumId; // Can be String or List
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/PushRegistrationInfo.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PushRegistrationInfo.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -28,6 +29,7 @@ public class PushRegistrationInfo implements Serializable, HasExtraFields {
     @JsonProperty("app_version")
     protected String appVersion; //GCM registration Id's are not guaranteed to work with the new app versions.
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ReleaseForm.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ReleaseForm.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -35,6 +36,7 @@ public class ReleaseForm implements Serializable, HasExtraFields {
     @JsonProperty("signature_image_id")
     protected Long signatureImageId;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ReleaseFormHtml.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ReleaseFormHtml.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class ReleaseFormHtml implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected String html;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Schema.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Schema.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -48,6 +49,7 @@ public class Schema implements Serializable, HasExtraFields, Comparable<Schema> 
     @JsonProperty("updated_at")
     protected String updated_at;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SchemaField.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SchemaField.java
@@ -53,6 +53,7 @@ public class SchemaField implements Serializable, HasExtraFields {
     @JsonProperty("ext")
     protected LinkedHashMap<String, Object> ext;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Schemas.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Schemas.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class Schemas implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<Schema> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Services.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Services.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class Services implements Serializable, HasExtraFields {
     @JsonProperty("type")
     protected String type;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ShareData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareData.java
@@ -55,6 +55,7 @@ public class ShareData implements Serializable, HasExtraFields {
     @JsonProperty("recipient_uid")
     protected String recipientUID;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ShareLink.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareLink.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -37,6 +38,7 @@ public class ShareLink implements Serializable, HasExtraFields {
     @JsonProperty("url")
     protected String url;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ShareMediaMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareMediaMetaData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -49,6 +50,7 @@ public class ShareMediaMetaData implements Serializable, HasExtraFields {
     @JsonProperty("creator")
     protected Creator creator;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ShareObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareObject.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -45,6 +46,7 @@ public class ShareObject implements Serializable, HasExtraFields {
     @JsonProperty("ugc_meta")
     protected ShareUgcMeta ugcMeta;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ShareUgcMeta.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareUgcMeta.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -36,6 +37,7 @@ public class ShareUgcMeta implements Serializable, HasExtraFields {
     @JsonProperty("formats")
     protected List<MediaFormat> formats;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/ShareUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareUser.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -29,6 +30,7 @@ public class ShareUser implements Serializable, HasExtraFields {
     @JsonProperty("type")
     protected String type;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Shares.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Shares.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class Shares implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SingleFlag.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleFlag.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class SingleFlag implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected Flag data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SingleLicenseChannel.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleLicenseChannel.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class SingleLicenseChannel implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected LicenseChannel data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SingleSchema.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleSchema.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -22,6 +23,7 @@ public class SingleSchema implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected Schema data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SingleShare.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleShare.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class SingleShare implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected ShareData data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SingleTask.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleTask.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class SingleTask implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected Task data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SingleTerm.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleTerm.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class SingleTerm implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected Term data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SingleUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleUser.java
@@ -1,9 +1,9 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -21,6 +21,7 @@ public class SingleUser implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected User user;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/StreamChannelData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/StreamChannelData.java
@@ -64,6 +64,7 @@ public class StreamChannelData implements Serializable, HasExtraFields {
     @JsonProperty("updated_at")
     protected String updatedAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/StreamData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/StreamData.java
@@ -52,6 +52,7 @@ public class StreamData implements Serializable, HasExtraFields {
     @JsonProperty("ext")
     protected LinkedHashMap<String, Object> ext;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Streams.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Streams.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class Streams implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<StreamData> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/StreamsInclude.java
+++ b/core/src/main/java/com/percolate/sdk/dto/StreamsInclude.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class StreamsInclude implements Serializable, HasExtraFields {
     @JsonProperty("channel")
     protected List<StreamChannelData> channels;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SuccessProperty.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SuccessProperty.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class SuccessProperty implements Serializable, HasExtraFields {
     @JsonProperty("success")
     protected String success;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/SuccessStatus.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SuccessStatus.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class SuccessStatus implements Serializable, HasExtraFields {
     @JsonProperty("success")
     protected SuccessProperty success;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Targeting.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Targeting.java
@@ -41,6 +41,7 @@ public class Targeting implements Serializable, HasExtraFields {
     @JsonProperty("work_networks")
     protected List<LinkedHashMap<String, Object>> workNetworks;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Task.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Task.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -54,6 +55,7 @@ public class Task implements Serializable, HasExtraFields {
     @JsonProperty("ordinal")
     protected Integer ordinal;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Tasks.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Tasks.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -28,6 +29,7 @@ public class Tasks implements Serializable, HasExtraFields {
     @JsonProperty("errors")
     protected List<LinkedHashMap<String, Object>> errors;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Term.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Term.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -64,6 +65,7 @@ public class Term implements Serializable, HasExtraFields {
         return hashCodeBuilder.build();
     }
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Terms.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Terms.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -27,6 +28,7 @@ public class Terms implements Serializable, HasExtraFields {
     @JsonProperty("errors")
     protected Errors errors;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Token.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Token.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -31,6 +32,7 @@ public class Token implements Serializable, HasExtraFields {
     @JsonProperty("pages")
     protected List<LinkedHashMap<String, Object>> pages;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TokenStatus.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TokenStatus.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -18,6 +19,7 @@ public class TokenStatus implements Serializable, HasExtraFields {
 
     protected Integer status;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Tokens.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Tokens.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -25,6 +26,7 @@ public class Tokens implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TopAnalytic.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TopAnalytic.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class TopAnalytic implements Serializable, HasExtraFields {
     @JsonProperty("score")
     protected Integer score;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Topic.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Topic.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -35,6 +36,7 @@ public class Topic implements Serializable, HasExtraFields {
     @JsonProperty("owner")
     protected License owner;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Topics.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Topics.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class Topics implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<Topic> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Translation.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Translation.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class Translation implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected TranslationData data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TranslationAttribution.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TranslationAttribution.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class TranslationAttribution implements Serializable, HasExtraFields {
     @JsonProperty("link")
     protected String link;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TranslationData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TranslationData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -32,6 +33,7 @@ public class TranslationData implements Serializable, HasExtraFields {
     @JsonProperty("attribution")
     protected TranslationAttribution attribution;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Tweet.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Tweet.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -102,6 +103,7 @@ public class Tweet implements Serializable, HasExtraFields {
     @JsonProperty("filter_level")
     protected String filterLevel;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterBlocks.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterBlocks.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -33,6 +34,7 @@ public class TwitterBlocks implements Serializable, HasExtraFields {
     @JsonProperty("previous_cursor_str")
     protected String previousCursorStr;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterConversationList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterConversationList.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class TwitterConversationList implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterConversationListData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterConversationListData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class TwitterConversationListData implements Serializable, HasExtraFields
     @JsonProperty("replied")
     protected boolean replied; //Set by ApiGetTwitterConversation, but not by ApiGetTwitterConversationThread
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterConversationMessage.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterConversationMessage.java
@@ -62,6 +62,7 @@ public class TwitterConversationMessage implements Serializable, HasExtraFields 
     @JsonProperty("created_at")
     protected String createdAt;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterConversationThread.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterConversationThread.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class TwitterConversationThread implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterInteractions.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterInteractions.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class TwitterInteractions implements Serializable, HasExtraFields {
     @JsonProperty("data")
     public TwitterMonitoringObject data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterInteractionsData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterInteractionsData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class TwitterInteractionsData implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<TwitterInteractionsDataObject> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterInteractionsDataObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterInteractionsDataObject.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class TwitterInteractionsDataObject implements Serializable, HasExtraFiel
     @JsonProperty("xobj")
     protected LinkedHashMap<String, Object> xobj;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterMonitoringObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterMonitoringObject.java
@@ -40,6 +40,7 @@ public class TwitterMonitoringObject implements Serializable, HasExtraFields {
     @JsonProperty("xobj")
     protected Tweet tweet;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterMonitoringObjects.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterMonitoringObjects.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class TwitterMonitoringObjects implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterQueries.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterQueries.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class TwitterQueries implements Serializable, HasExtraFields {
     @JsonProperty("pagination")
     protected PaginationData paginationData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterQuery.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterQuery.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -67,6 +68,7 @@ public class TwitterQuery implements Serializable, HasExtraFields {
     @JsonProperty("monthly_usage_limit")
     protected Long monthlyUsageLimit;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterRelationship.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterRelationship.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -23,6 +24,7 @@ public class TwitterRelationship implements Serializable, HasExtraFields {
     @JsonProperty("target")
     protected TwitterRelationshipStatus target;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterRelationshipStatus.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterRelationshipStatus.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -63,6 +64,7 @@ public class TwitterRelationshipStatus implements Serializable, HasExtraFields {
     @JsonProperty("want_retweets")
     protected Object wantsRetweets;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterRelationships.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterRelationships.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -20,6 +21,7 @@ public class TwitterRelationships implements Serializable, HasExtraFields {
     @JsonProperty("relationship")
     protected TwitterRelationship relationship;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterStatus.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterStatus.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -86,6 +87,7 @@ public class TwitterStatus implements Serializable, HasExtraFields {
     @JsonProperty("retweeted_status")
     protected Tweet retweetedStatus;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterUser.java
@@ -159,6 +159,7 @@ public class TwitterUser implements Serializable, HasExtraFields {
     @JsonProperty("errors")
     protected List<LinkedHashMap<String, Object>> errors;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/User.java
+++ b/core/src/main/java/com/percolate/sdk/dto/User.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -64,6 +65,7 @@ public class User implements Serializable, HasExtraFields {
     @JsonProperty("errors")
     protected List<LinkedHashMap<String, Object>> errors;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/UserRoles.java
+++ b/core/src/main/java/com/percolate/sdk/dto/UserRoles.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -22,6 +23,7 @@ public class UserRoles implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<UserRolesLicenseData> userRolesLicenseData;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/UserRolesLicenseCapabilities.java
+++ b/core/src/main/java/com/percolate/sdk/dto/UserRolesLicenseCapabilities.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -33,6 +34,7 @@ public class UserRolesLicenseCapabilities implements Serializable, HasExtraField
     @JsonProperty("implies")
     protected List<String> implies;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/UserRolesLicenseData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/UserRolesLicenseData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -36,6 +37,7 @@ public class UserRolesLicenseData implements Serializable, HasExtraFields {
     @JsonProperty("tags")
     protected List<String> tags;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Users.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Users.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class Users implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<User> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/V5Meta.java
+++ b/core/src/main/java/com/percolate/sdk/dto/V5Meta.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -24,6 +25,7 @@ public class V5Meta implements Serializable, HasExtraFields {
     @JsonProperty("total")
     protected Long total;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/VideoFormatMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/VideoFormatMetaData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -26,6 +27,7 @@ public class VideoFormatMetaData implements Serializable, HasExtraFields {
     @JsonProperty("height")
     protected Integer height;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/Workflow.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Workflow.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class Workflow implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<WorkflowData> data;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/WorkflowData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/WorkflowData.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -41,6 +42,7 @@ public class WorkflowData implements Serializable, HasExtraFields {
     @JsonProperty("steps")
     protected List<WorkflowStep> steps;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/WorkflowHistory.java
+++ b/core/src/main/java/com/percolate/sdk/dto/WorkflowHistory.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -21,6 +22,7 @@ public class WorkflowHistory implements Serializable, HasExtraFields {
     @JsonProperty("data")
     protected List<WorkflowHistoryEvent> events;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/WorkflowHistoryEvent.java
+++ b/core/src/main/java/com/percolate/sdk/dto/WorkflowHistoryEvent.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -48,6 +49,7 @@ public class WorkflowHistoryEvent implements Serializable, HasExtraFields {
     @JsonProperty("error_id")
     protected String errorId;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/WorkflowStep.java
+++ b/core/src/main/java/com/percolate/sdk/dto/WorkflowStep.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percolate.sdk.interfaces.HasExtraFields;
@@ -36,6 +37,7 @@ public class WorkflowStep implements Serializable, HasExtraFields {
     @JsonProperty("users")
     protected List<User> users;
 
+    @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
     @Override


### PR DESCRIPTION
Added `@JsonIgnore` annotations to all `extraFields` fields on DTOs to stop fields from being included in `POST` requests to API.