### PR TITLE
Addition of v5/me endpoint

### DIFF
--- a/api/src/main/java/com/percolate/sdk/api/request/users/UsersRequest.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/users/UsersRequest.java
@@ -3,6 +3,7 @@ package com.percolate.sdk.api.request.users;
 import com.percolate.sdk.api.PercolateApi;
 import com.percolate.sdk.api.utils.RetrofitApiFactory;
 import com.percolate.sdk.dto.ChangePasswordError;
+import com.percolate.sdk.dto.SingleUser;
 import com.percolate.sdk.dto.Users;
 import org.jetbrains.annotations.NotNull;
 import retrofit2.Call;
@@ -17,6 +18,15 @@ public class UsersRequest {
 
     public UsersRequest(@NotNull PercolateApi context) {
         this.service = new RetrofitApiFactory(context).getService(UsersService.class);
+    }
+
+    /**
+     * Query "me" endpoint.
+     *
+     * @return {@link Call} object.
+     */
+    public Call<SingleUser> me() {
+        return service.me();
     }
 
     /**

--- a/api/src/main/java/com/percolate/sdk/api/request/users/UsersService.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/users/UsersService.java
@@ -2,12 +2,10 @@ package com.percolate.sdk.api.request.users;
 
 import com.percolate.sdk.api.config.Endpoints;
 import com.percolate.sdk.dto.ChangePasswordError;
+import com.percolate.sdk.dto.SingleUser;
 import com.percolate.sdk.dto.Users;
 import retrofit2.Call;
-import retrofit2.http.GET;
-import retrofit2.http.PUT;
-import retrofit2.http.Path;
-import retrofit2.http.QueryMap;
+import retrofit2.http.*;
 
 import java.util.Map;
 
@@ -15,6 +13,9 @@ import java.util.Map;
  * Percolate v3/users and v5/user API definition.
  */
 interface UsersService {
+
+    @GET(Endpoints.API_V5_PATH + "/me")
+    Call<SingleUser> me();
 
     @GET(Endpoints.API_V3_PATH + "/users")
     Call<Users> get(@QueryMap Map<String, Object> params);

--- a/api/src/main/java/com/percolate/sdk/api/utils/RetrofitLogic.java
+++ b/api/src/main/java/com/percolate/sdk/api/utils/RetrofitLogic.java
@@ -39,7 +39,7 @@ public class RetrofitLogic {
     /**
      * Construct instance.
      */
-    RetrofitLogic(@NotNull PercolateApi context) {
+    public RetrofitLogic(@NotNull PercolateApi context) {
         this.context = context;
     }
 


### PR DESCRIPTION
- Addition of `v5/me` request to user service.
- `RetrofitLogic` constructor is now public to provide way to register custom endpoints.