### PR TITLE
scope_ids params fixes

### DIFF
--- a/api/src/main/java/com/percolate/sdk/api/request/channel/ChannelParams.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/channel/ChannelParams.java
@@ -1,6 +1,9 @@
 package com.percolate.sdk.api.request.channel;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -13,8 +16,8 @@ public class ChannelParams {
     public ChannelParams() {
     }
 
-    public ChannelParams scopeId(String scopeId) {
-        params.put("scope_ids", scopeId);
+    public ChannelParams scopeIds(List<String> scopeIds) {
+        params.put("scope_ids", StringUtils.join(scopeIds, ","));
         return this;
     }
 

--- a/api/src/main/java/com/percolate/sdk/api/request/platform/PlatformsParams.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/platform/PlatformsParams.java
@@ -1,6 +1,9 @@
 package com.percolate.sdk.api.request.platform;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -13,8 +16,8 @@ public class PlatformsParams {
     public PlatformsParams() {
     }
 
-    public PlatformsParams scopeId(String scopeId) {
-        params.put("scope_ids", scopeId);
+    public PlatformsParams scopeIds(List<String> scopeIds) {
+        params.put("scope_ids", StringUtils.join(scopeIds, ","));
         return this;
     }
 

--- a/api/src/main/java/com/percolate/sdk/api/request/responses/CannedResponsesParams.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/responses/CannedResponsesParams.java
@@ -3,6 +3,7 @@ package com.percolate.sdk.api.request.responses;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -15,7 +16,7 @@ public class CannedResponsesParams {
     public CannedResponsesParams() {
     }
 
-    public CannedResponsesParams scopeIds(String scopeIds){
+    public CannedResponsesParams scopeIds(List<String> scopeIds){
         params.put("scope_ids", StringUtils.join(scopeIds, ","));
         return this;
     }

--- a/api/src/main/java/com/percolate/sdk/api/request/streams/StreamsParams.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/streams/StreamsParams.java
@@ -22,7 +22,7 @@ public class StreamsParams {
         return this;
     }
 
-    public StreamsParams scopeIds(String scopeIds) {
+    public StreamsParams scopeIds(List<String> scopeIds) {
         params.put("scope_ids", StringUtils.join(scopeIds, ","));
         return this;
     }

--- a/api/src/main/java/com/percolate/sdk/api/request/terms/TermsParams.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/terms/TermsParams.java
@@ -22,8 +22,8 @@ public class TermsParams {
         return this;
     }
 
-    public TermsParams scopeId(String scopeId) {
-        params.put("scope_ids", scopeId);
+    public TermsParams scopeIds(List<String> scopeIds) {
+        params.put("scope_ids", StringUtils.join(scopeIds, ","));
         return this;
     }
 


### PR DESCRIPTION
Fixed scope_ids params to always be `List<String>`