### PR TITLE
Exclude null fields in API requests

### DIFF
--- a/core/src/main/java/com/percolate/sdk/dto/ActivityStream.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ActivityStream.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ActivityStream implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6182834338225033194L;

--- a/core/src/main/java/com/percolate/sdk/dto/ActivityStreamData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ActivityStreamData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ActivityStreamData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7701722333929308105L;

--- a/core/src/main/java/com/percolate/sdk/dto/ActivityStreamMetadata.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ActivityStreamMetadata.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ActivityStreamMetadata implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7583076661503256595L;

--- a/core/src/main/java/com/percolate/sdk/dto/ApprovalPool.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ApprovalPool.java
@@ -1,9 +1,7 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
+
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApprovalPool implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -5075350952795805061L;

--- a/core/src/main/java/com/percolate/sdk/dto/ApprovalPoolStep.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ApprovalPoolStep.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApprovalPoolStep implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -4122378363734928928L;

--- a/core/src/main/java/com/percolate/sdk/dto/ApprovalPools.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ApprovalPools.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApprovalPools implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -4542197289262070188L;

--- a/core/src/main/java/com/percolate/sdk/dto/AuthTokenData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthTokenData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthTokenData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8168635337161980833L;

--- a/core/src/main/java/com/percolate/sdk/dto/AuthTokenPostData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthTokenPostData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthTokenPostData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8061518829366872013L;

--- a/core/src/main/java/com/percolate/sdk/dto/AuthorizeData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthorizeData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthorizeData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -6329025686470303708L;

--- a/core/src/main/java/com/percolate/sdk/dto/AuthorizeDataExt.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthorizeDataExt.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthorizeDataExt implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6700661611326561278L;

--- a/core/src/main/java/com/percolate/sdk/dto/AuthorizePostData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthorizePostData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthorizePostData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 8282500106274999046L;

--- a/core/src/main/java/com/percolate/sdk/dto/AuthorizePostDataExt.java
+++ b/core/src/main/java/com/percolate/sdk/dto/AuthorizePostDataExt.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthorizePostDataExt implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7041663935928258031L;

--- a/core/src/main/java/com/percolate/sdk/dto/Autocomplete.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Autocomplete.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Autocomplete implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6883166262212102498L;

--- a/core/src/main/java/com/percolate/sdk/dto/Brand.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Brand.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Brand implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 8527573711365326453L;

--- a/core/src/main/java/com/percolate/sdk/dto/Brew.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Brew.java
@@ -1,10 +1,7 @@
 
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Brew implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3481043846462293641L;

--- a/core/src/main/java/com/percolate/sdk/dto/BrewLicenceConnection.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewLicenceConnection.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BrewLicenceConnection implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7688380520853872L;

--- a/core/src/main/java/com/percolate/sdk/dto/BrewLinkData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewLinkData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BrewLinkData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2498535372228330993L;

--- a/core/src/main/java/com/percolate/sdk/dto/BrewLinks.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewLinks.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BrewLinks implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -95774588881853668L;

--- a/core/src/main/java/com/percolate/sdk/dto/BrewUsers.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewUsers.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BrewUsers implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6069464957101643016L;

--- a/core/src/main/java/com/percolate/sdk/dto/BrewsForLicense.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BrewsForLicense.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BrewsForLicense implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1807753700970904760L;

--- a/core/src/main/java/com/percolate/sdk/dto/Brief.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Brief.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Brief implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2614032831697058538L;

--- a/core/src/main/java/com/percolate/sdk/dto/BriefData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/BriefData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BriefData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7778976393258821219L;

--- a/core/src/main/java/com/percolate/sdk/dto/Briefs.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Briefs.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Briefs implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7778976393258821219L;

--- a/core/src/main/java/com/percolate/sdk/dto/Campaign.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Campaign.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Campaign implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3141164169992839973L;

--- a/core/src/main/java/com/percolate/sdk/dto/CampaignSectionData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CampaignSectionData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CampaignSectionData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2202666222120218397L;

--- a/core/src/main/java/com/percolate/sdk/dto/Campaigns.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Campaigns.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Campaigns implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2204965979593854688L;

--- a/core/src/main/java/com/percolate/sdk/dto/CannedResponseData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CannedResponseData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CannedResponseData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -4152482183994100675L;

--- a/core/src/main/java/com/percolate/sdk/dto/CannedResponses.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CannedResponses.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CannedResponses implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -6132829467032322387L;

--- a/core/src/main/java/com/percolate/sdk/dto/CannedResponsesMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CannedResponsesMetaData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CannedResponsesMetaData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3410991984621577045L;

--- a/core/src/main/java/com/percolate/sdk/dto/ChangePasswordError.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ChangePasswordError.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChangePasswordError implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8065590165958930960L;

--- a/core/src/main/java/com/percolate/sdk/dto/Channel.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Channel.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Channel implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 4429915726701722436L;

--- a/core/src/main/java/com/percolate/sdk/dto/ChannelV5.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ChannelV5.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -18,6 +15,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChannelV5 implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2007591110523885960L;

--- a/core/src/main/java/com/percolate/sdk/dto/Channels.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Channels.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Channels implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6277841434236148178L;

--- a/core/src/main/java/com/percolate/sdk/dto/Comment.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Comment.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Comment implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -348154790646104399L;

--- a/core/src/main/java/com/percolate/sdk/dto/CommentContextExt.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CommentContextExt.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CommentContextExt implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1910571672664069331L;

--- a/core/src/main/java/com/percolate/sdk/dto/CommentData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CommentData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CommentData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7043763753044346096L;

--- a/core/src/main/java/com/percolate/sdk/dto/Comments.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Comments.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Comments implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3094776335568238621L;

--- a/core/src/main/java/com/percolate/sdk/dto/CommentsInclude.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CommentsInclude.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CommentsInclude implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -5501631821037467976L;

--- a/core/src/main/java/com/percolate/sdk/dto/Creator.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Creator.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Creator implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -5520630615228426626L;

--- a/core/src/main/java/com/percolate/sdk/dto/CurrencyValue.java
+++ b/core/src/main/java/com/percolate/sdk/dto/CurrencyValue.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CurrencyValue implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 9084918391516878711L;

--- a/core/src/main/java/com/percolate/sdk/dto/DateRangeValue.java
+++ b/core/src/main/java/com/percolate/sdk/dto/DateRangeValue.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class DateRangeValue implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1573058536502372203L;

--- a/core/src/main/java/com/percolate/sdk/dto/EnabledProperty.java
+++ b/core/src/main/java/com/percolate/sdk/dto/EnabledProperty.java
@@ -3,6 +3,7 @@ package com.percolate.sdk.dto;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +14,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class EnabledProperty implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -6814557904913818377L;

--- a/core/src/main/java/com/percolate/sdk/dto/Entry.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Entry.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Entry implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -6228332680774988388L;

--- a/core/src/main/java/com/percolate/sdk/dto/Error.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Error.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Error implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6959823337410858600L;

--- a/core/src/main/java/com/percolate/sdk/dto/Errors.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Errors.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Errors implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -6908100623351411037L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationList.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookConversationList implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3113230247794055362L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationListData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationListData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookConversationListData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2053250147383536912L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessage.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessage.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookConversationMessage implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7978616001157824820L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessageId.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessageId.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookConversationMessageId implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3433079150488185863L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessageIdData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationMessageIdData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookConversationMessageIdData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 8841591131753919347L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookConversationThread.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookConversationThread.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookConversationThread implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6153718901755261878L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMention.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMention.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMention implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2635394381099711188L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMentionData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMentionData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMentionData implements Serializable, HasExtraFields, Comparable<FacebookMentionData> {
 
     private static final long serialVersionUID = -8684245906086050351L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMentionPicture.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMentionPicture.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMentionPicture implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -221662608585538150L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMentionPictureData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMentionPictureData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMentionPictureData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1631907049621162039L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMentions.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMentions.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMentions implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1598302510558778617L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachment.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachment.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMessageAttachment implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2968749522512483725L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachmentImageData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachmentImageData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMessageAttachmentImageData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -9078692815738333257L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachments.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageAttachments.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMessageAttachments implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -5263016879014781921L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageExtendedData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageExtendedData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMessageExtendedData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -5549405235141235537L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMessageKeyValueList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMessageKeyValueList.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMessageKeyValueList implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8069980492365035119L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObject.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMonitoringObject implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3763956518885813706L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObjects.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObjects.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMonitoringObjects implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6826014384269799318L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObjectsList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringObjectsList.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -8,6 +9,7 @@ import java.util.ArrayList;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMonitoringObjectsList extends ArrayList<FacebookMonitoringObject> {
 
     private static final long serialVersionUID = 6737081313836939582L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringUser.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMonitoringUser implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1597201298258204897L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringXObj.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookMonitoringXObj.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookMonitoringXObj implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1729202563494110505L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookUser.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookUser implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -694364618125565258L;

--- a/core/src/main/java/com/percolate/sdk/dto/FacebookUserDataList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FacebookUserDataList.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacebookUserDataList implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -305868333395532510L;

--- a/core/src/main/java/com/percolate/sdk/dto/Facets.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Facets.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Facets implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -502807027675904076L;

--- a/core/src/main/java/com/percolate/sdk/dto/FeatureData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FeatureData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FeatureData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 4652077873067170980L;

--- a/core/src/main/java/com/percolate/sdk/dto/Features.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Features.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Features implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6303783337575122745L;

--- a/core/src/main/java/com/percolate/sdk/dto/Flag.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Flag.java
@@ -1,10 +1,7 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.annotation.*;
+ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.percolate.sdk.enums.FlaggingStatusType;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -15,6 +12,7 @@ import java.util.*;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Flag implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1680480238150106321L;

--- a/core/src/main/java/com/percolate/sdk/dto/FlagOwner.java
+++ b/core/src/main/java/com/percolate/sdk/dto/FlagOwner.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FlagOwner implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -6118511276801966120L;

--- a/core/src/main/java/com/percolate/sdk/dto/Flags.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Flags.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Flags implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7832152877428648944L;

--- a/core/src/main/java/com/percolate/sdk/dto/Follower.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Follower.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Follower implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1691475328894439732L;

--- a/core/src/main/java/com/percolate/sdk/dto/Followers.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Followers.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Followers implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8232801090049914890L;

--- a/core/src/main/java/com/percolate/sdk/dto/ImageLicense.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ImageLicense.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ImageLicense implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3384937583884049836L;

--- a/core/src/main/java/com/percolate/sdk/dto/ImageSize.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ImageSize.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ImageSize implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7265923535296742332L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramComment.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramComment.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramComment implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7233760905645099831L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramComments.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramComments.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramComments implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3362006676760456983L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramImageLocation.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramImageLocation.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramImageLocation implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1603230787329290303L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramIncludeMediaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramIncludeMediaData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramIncludeMediaData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2952987534564201254L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramIncludes.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramIncludes.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramIncludes implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 390131722143510937L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramLikes.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramLikes.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramLikes implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 174929256400217126L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMedia.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMedia.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramMedia implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1174438864492858419L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMediaComments.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMediaComments.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramMediaComments implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3606954535139845464L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMediaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMediaData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramMediaData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5873971121884014169L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMediaUrl.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMediaUrl.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramMediaUrl implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5520507469041979737L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMediaUrls.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMediaUrls.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramMediaUrls implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2367488877752973375L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObject.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramMonitoringObject implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8868746361534487444L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObjectMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObjectMetaData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramMonitoringObjectMetaData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3615282804419551717L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObjects.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramMonitoringObjects.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramMonitoringObjects implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -731785363175190478L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramPhotoPosition.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramPhotoPosition.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramPhotoPosition implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7862112892290706492L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramRecentMedia.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramRecentMedia.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramRecentMedia implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5997348676516800625L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramRequestMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramRequestMetaData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramRequestMetaData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 8605602985756380262L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramSingleMonitoringObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramSingleMonitoringObject.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramSingleMonitoringObject implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1851219957906612730L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramUser.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramUser implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2983231878313103195L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramUserCounts.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramUserCounts.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramUserCounts implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1879803008621273795L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramUserData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramUserData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramUserData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6985259701897119100L;

--- a/core/src/main/java/com/percolate/sdk/dto/InstagramUsersInPhoto.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InstagramUsersInPhoto.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstagramUsersInPhoto implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2565579330704972172L;

--- a/core/src/main/java/com/percolate/sdk/dto/InteractionData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InteractionData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InteractionData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2244260563471640657L;

--- a/core/src/main/java/com/percolate/sdk/dto/Interactions.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Interactions.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Interactions implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3268412933584812239L;

--- a/core/src/main/java/com/percolate/sdk/dto/InteractionsMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InteractionsMetaData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InteractionsMetaData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1727114334506910922L;

--- a/core/src/main/java/com/percolate/sdk/dto/InteractionsMetaDataQuery.java
+++ b/core/src/main/java/com/percolate/sdk/dto/InteractionsMetaDataQuery.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InteractionsMetaDataQuery implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8429083583720162263L;

--- a/core/src/main/java/com/percolate/sdk/dto/Keywords.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Keywords.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Keywords implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6882567642837188994L;

--- a/core/src/main/java/com/percolate/sdk/dto/License.java
+++ b/core/src/main/java/com/percolate/sdk/dto/License.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -19,6 +16,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class License implements Serializable, HasExtraFields, Comparable<License> {
 
     private static final long serialVersionUID = -1659638539635426756L;

--- a/core/src/main/java/com/percolate/sdk/dto/LicenseChannel.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicenseChannel.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LicenseChannel implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5650271549581035867L;

--- a/core/src/main/java/com/percolate/sdk/dto/LicenseChannels.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicenseChannels.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LicenseChannels implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2730987612393184149L;

--- a/core/src/main/java/com/percolate/sdk/dto/LicensePublishingSettings.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicensePublishingSettings.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LicensePublishingSettings implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -5154375915441246126L;

--- a/core/src/main/java/com/percolate/sdk/dto/LicenseUserInfo.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicenseUserInfo.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LicenseUserInfo implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -6705313614715852525L;

--- a/core/src/main/java/com/percolate/sdk/dto/LicenseUsers.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicenseUsers.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LicenseUsers implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 8919965239761196783L;

--- a/core/src/main/java/com/percolate/sdk/dto/Licenses.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Licenses.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Licenses implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3284944770858651980L;

--- a/core/src/main/java/com/percolate/sdk/dto/Link.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Link.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -18,6 +15,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Link implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1654480346828025928L;

--- a/core/src/main/java/com/percolate/sdk/dto/LocalCreatedAt.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LocalCreatedAt.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LocalCreatedAt implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1836316412476551789L;

--- a/core/src/main/java/com/percolate/sdk/dto/Media.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Media.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -15,6 +12,7 @@ import java.util.*;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Media implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 69550139319470210L;

--- a/core/src/main/java/com/percolate/sdk/dto/MediaFormat.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaFormat.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MediaFormat implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -4849494254932997755L;

--- a/core/src/main/java/com/percolate/sdk/dto/MediaItems.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaItems.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -8,6 +9,7 @@ import java.util.ArrayList;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MediaItems extends ArrayList<Media> {
 
     private static final long serialVersionUID = -7668204906873975115L;

--- a/core/src/main/java/com/percolate/sdk/dto/MediaList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaList.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +10,7 @@ import java.util.*;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MediaList implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1426883209215551876L;

--- a/core/src/main/java/com/percolate/sdk/dto/MediaMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaMetaData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MediaMetaData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7544126992287411792L;

--- a/core/src/main/java/com/percolate/sdk/dto/MediaMetaDataHolder.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaMetaDataHolder.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MediaMetaDataHolder implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 863071203532221745L;

--- a/core/src/main/java/com/percolate/sdk/dto/MediaReleaseResponse.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaReleaseResponse.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MediaReleaseResponse implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7661572721406666179L;

--- a/core/src/main/java/com/percolate/sdk/dto/MediaReleaseResponseData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MediaReleaseResponseData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MediaReleaseResponseData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3658251682257161899L;

--- a/core/src/main/java/com/percolate/sdk/dto/Mention.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Mention.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Mention implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8957592944012297251L;

--- a/core/src/main/java/com/percolate/sdk/dto/MobileAppPushToken.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MobileAppPushToken.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MobileAppPushToken implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1641817014316211475L;

--- a/core/src/main/java/com/percolate/sdk/dto/MobileAppPushTokenData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MobileAppPushTokenData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MobileAppPushTokenData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6489210695336096464L;

--- a/core/src/main/java/com/percolate/sdk/dto/MobileVersionCheck.java
+++ b/core/src/main/java/com/percolate/sdk/dto/MobileVersionCheck.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MobileVersionCheck implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2273464833455803057L;

--- a/core/src/main/java/com/percolate/sdk/dto/OAuthToken.java
+++ b/core/src/main/java/com/percolate/sdk/dto/OAuthToken.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthToken implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1779567140789964620L;

--- a/core/src/main/java/com/percolate/sdk/dto/OAuthTokenData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/OAuthTokenData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OAuthTokenData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6215034140127772622L;

--- a/core/src/main/java/com/percolate/sdk/dto/OwnedChannel.java
+++ b/core/src/main/java/com/percolate/sdk/dto/OwnedChannel.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class OwnedChannel implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -267444600899027053L;

--- a/core/src/main/java/com/percolate/sdk/dto/Owner.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Owner.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Owner implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5308338463018649712L;

--- a/core/src/main/java/com/percolate/sdk/dto/PaginationData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PaginationData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PaginationData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3822172876701770176L;

--- a/core/src/main/java/com/percolate/sdk/dto/Platform.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Platform.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -18,6 +15,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Platform implements Serializable, HasExtraFields, Comparable<Platform> {
 
     private static final long serialVersionUID = 487676188878352763L;

--- a/core/src/main/java/com/percolate/sdk/dto/Platforms.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Platforms.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Platforms implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8470273481563594530L;

--- a/core/src/main/java/com/percolate/sdk/dto/Plug.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Plug.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Plug implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 8655115311837847481L;

--- a/core/src/main/java/com/percolate/sdk/dto/Plugs.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Plugs.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Plugs implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6511974218386725101L;

--- a/core/src/main/java/com/percolate/sdk/dto/Post.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Post.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +10,7 @@ import java.util.*;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Post implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1092763210799796857L;

--- a/core/src/main/java/com/percolate/sdk/dto/PostSet.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostSet.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostSet implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2406736684378546245L;

--- a/core/src/main/java/com/percolate/sdk/dto/PostSetData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostSetData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +10,7 @@ import java.util.*;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostSetData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7566682514171654050L;

--- a/core/src/main/java/com/percolate/sdk/dto/PostV5.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostV5.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostV5 implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7447298993127654587L;

--- a/core/src/main/java/com/percolate/sdk/dto/PostV5Data.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostV5Data.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -17,6 +14,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostV5Data implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2143339291862169519L;

--- a/core/src/main/java/com/percolate/sdk/dto/PostV5Include.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostV5Include.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostV5Include implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3361111564265766009L;

--- a/core/src/main/java/com/percolate/sdk/dto/PostsV5.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostsV5.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostsV5 implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 4435737568483765895L;

--- a/core/src/main/java/com/percolate/sdk/dto/Publishing.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Publishing.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Publishing implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1136384423211158167L;

--- a/core/src/main/java/com/percolate/sdk/dto/PushRegistrationInfo.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PushRegistrationInfo.java
@@ -1,8 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +14,9 @@ import java.util.Map;
  * **Note: Uses JsonProperty declarations so that it can be stored in session, which
  * serializes objects to JSON when they are stored
  */
+@SuppressWarnings("UnusedDeclaration")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PushRegistrationInfo implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5293786670952513731L;

--- a/core/src/main/java/com/percolate/sdk/dto/PushRegistrationInfo.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PushRegistrationInfo.java
@@ -12,8 +12,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Used by Push Library to holds registration ID that will be saved in SessionManager.
- * **Note: Uses JsonProperty declariations so that it can be stored in SessionManager, which
+ * Used by Push Library to holds registration ID that will be saved in session.
+ * **Note: Uses JsonProperty declarations so that it can be stored in session, which
  * serializes objects to JSON when they are stored
  */
 public class PushRegistrationInfo implements Serializable, HasExtraFields {

--- a/core/src/main/java/com/percolate/sdk/dto/ReleaseForm.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ReleaseForm.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReleaseForm implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8124374256190243861L;

--- a/core/src/main/java/com/percolate/sdk/dto/ReleaseFormHtml.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ReleaseFormHtml.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReleaseFormHtml implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2303492161064078319L;

--- a/core/src/main/java/com/percolate/sdk/dto/Schema.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Schema.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -15,6 +12,7 @@ import java.util.*;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Schema implements Serializable, HasExtraFields, Comparable<Schema> {
 
     private static final long serialVersionUID = -6137788601263891457L;

--- a/core/src/main/java/com/percolate/sdk/dto/SchemaField.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SchemaField.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SchemaField implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8430096455662427494L;

--- a/core/src/main/java/com/percolate/sdk/dto/Schemas.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Schemas.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Schemas implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -397962289275402466L;

--- a/core/src/main/java/com/percolate/sdk/dto/Services.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Services.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Services implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7087020580042995262L;

--- a/core/src/main/java/com/percolate/sdk/dto/ShareData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ShareData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2218654368933208095L;

--- a/core/src/main/java/com/percolate/sdk/dto/ShareLink.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareLink.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ShareLink implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5988330662816241981L;

--- a/core/src/main/java/com/percolate/sdk/dto/ShareMediaMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareMediaMetaData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ShareMediaMetaData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3046289637403627091L;

--- a/core/src/main/java/com/percolate/sdk/dto/ShareObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareObject.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ShareObject implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8957804320866631989L;

--- a/core/src/main/java/com/percolate/sdk/dto/ShareUgcMeta.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareUgcMeta.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ShareUgcMeta implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 8241743059330507001L;

--- a/core/src/main/java/com/percolate/sdk/dto/ShareUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/ShareUser.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ShareUser implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6179864185590640457L;

--- a/core/src/main/java/com/percolate/sdk/dto/Shares.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Shares.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Shares implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3716896257654739360L;

--- a/core/src/main/java/com/percolate/sdk/dto/SingleFlag.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleFlag.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SingleFlag implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7070120286537326955L;

--- a/core/src/main/java/com/percolate/sdk/dto/SingleLicenseChannel.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleLicenseChannel.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SingleLicenseChannel implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3191195698991006335L;

--- a/core/src/main/java/com/percolate/sdk/dto/SingleSchema.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleSchema.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
  */
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SingleSchema implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3213350568663955162L;

--- a/core/src/main/java/com/percolate/sdk/dto/SingleShare.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleShare.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SingleShare implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -5215388855107200846L;

--- a/core/src/main/java/com/percolate/sdk/dto/SingleTask.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleTask.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SingleTask implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6527642196923216565L;

--- a/core/src/main/java/com/percolate/sdk/dto/SingleTerm.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleTerm.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SingleTerm implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2660978473371121477L;

--- a/core/src/main/java/com/percolate/sdk/dto/SingleUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SingleUser.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SingleUser implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 4362687636696187116L;

--- a/core/src/main/java/com/percolate/sdk/dto/StreamChannelData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/StreamChannelData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StreamChannelData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6222465143988267593L;

--- a/core/src/main/java/com/percolate/sdk/dto/StreamData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/StreamData.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StreamData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2489176252831188435L;

--- a/core/src/main/java/com/percolate/sdk/dto/Streams.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Streams.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Streams implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3022425564996288651L;

--- a/core/src/main/java/com/percolate/sdk/dto/StreamsInclude.java
+++ b/core/src/main/java/com/percolate/sdk/dto/StreamsInclude.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StreamsInclude implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6913934210095835536L;

--- a/core/src/main/java/com/percolate/sdk/dto/SuccessProperty.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SuccessProperty.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SuccessProperty implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6097598342255737647L;

--- a/core/src/main/java/com/percolate/sdk/dto/SuccessStatus.java
+++ b/core/src/main/java/com/percolate/sdk/dto/SuccessStatus.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SuccessStatus implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 8975251171799014170L;

--- a/core/src/main/java/com/percolate/sdk/dto/Targeting.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Targeting.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Targeting implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3528442782770731771L;

--- a/core/src/main/java/com/percolate/sdk/dto/Task.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Task.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Task implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -6170554872371926425L;

--- a/core/src/main/java/com/percolate/sdk/dto/Tasks.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Tasks.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Tasks implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1442229879990455001L;

--- a/core/src/main/java/com/percolate/sdk/dto/Term.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Term.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -17,6 +14,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Term implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 3098198274190964473L;

--- a/core/src/main/java/com/percolate/sdk/dto/Terms.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Terms.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Terms implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1574288769222247406L;

--- a/core/src/main/java/com/percolate/sdk/dto/Token.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Token.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Token implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -9204311148594925317L;

--- a/core/src/main/java/com/percolate/sdk/dto/TokenStatus.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TokenStatus.java
@@ -3,6 +3,7 @@ package com.percolate.sdk.dto;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +14,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TokenStatus implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 619792793077213566L;

--- a/core/src/main/java/com/percolate/sdk/dto/Tokens.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Tokens.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Tokens implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1957222789397691534L;

--- a/core/src/main/java/com/percolate/sdk/dto/TopAnalytic.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TopAnalytic.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TopAnalytic implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5993155913464792085L;

--- a/core/src/main/java/com/percolate/sdk/dto/Topic.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Topic.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Topic implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -7042873740209373803L;

--- a/core/src/main/java/com/percolate/sdk/dto/Topics.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Topics.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Topics implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 791424067589827022L;

--- a/core/src/main/java/com/percolate/sdk/dto/Translation.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Translation.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Translation implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6802825796553326017L;

--- a/core/src/main/java/com/percolate/sdk/dto/TranslationAttribution.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TranslationAttribution.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TranslationAttribution implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -4754494901033332462L;

--- a/core/src/main/java/com/percolate/sdk/dto/TranslationData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TranslationData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TranslationData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -4721866404655539374L;

--- a/core/src/main/java/com/percolate/sdk/dto/Tweet.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Tweet.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Tweet implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5295422780107833868L;

--- a/core/src/main/java/com/percolate/sdk/dto/TweetList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TweetList.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -8,6 +9,7 @@ import java.util.ArrayList;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TweetList extends ArrayList<Tweet> {
 
     private static final long serialVersionUID = -3485380119726273056L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterBlocks.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterBlocks.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterBlocks implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6669960706326459027L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterConversationList.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterConversationList.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterConversationList implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 2748281791219290036L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterConversationListData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterConversationListData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterConversationListData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7377475363379793838L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterConversationMessage.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterConversationMessage.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +10,7 @@ import java.util.*;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterConversationMessage implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7326061449551179235L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterConversationThread.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterConversationThread.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterConversationThread implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6153718901755261878L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterInteractions.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterInteractions.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterInteractions implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1582424847746679299L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterInteractionsData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterInteractionsData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterInteractionsData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8562006021982525923L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterInteractionsDataObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterInteractionsDataObject.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterInteractionsDataObject implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5095395185852262987L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterMonitoringObject.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterMonitoringObject.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterMonitoringObject implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -6192973897879987770L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterMonitoringObjects.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterMonitoringObjects.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterMonitoringObjects implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 7493861292446960392L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterQueries.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterQueries.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterQueries implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5831728428416471410L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterQuery.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterQuery.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,6 +10,7 @@ import java.util.*;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterQuery implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 4619768390675966837L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterRelationship.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterRelationship.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterRelationship implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -112592603356726870L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterRelationshipStatus.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterRelationshipStatus.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterRelationshipStatus implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -8436368374610963582L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterRelationships.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterRelationships.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterRelationships implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 4587414576692739644L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterStatus.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterStatus.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterStatus implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -2477125899122094140L;

--- a/core/src/main/java/com/percolate/sdk/dto/TwitterUser.java
+++ b/core/src/main/java/com/percolate/sdk/dto/TwitterUser.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -17,6 +14,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TwitterUser implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3340107184258855542L;

--- a/core/src/main/java/com/percolate/sdk/dto/User.java
+++ b/core/src/main/java/com/percolate/sdk/dto/User.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class User implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1410394764791629912L;

--- a/core/src/main/java/com/percolate/sdk/dto/UserRoles.java
+++ b/core/src/main/java/com/percolate/sdk/dto/UserRoles.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -16,6 +13,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserRoles implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3360246480079743338L;

--- a/core/src/main/java/com/percolate/sdk/dto/UserRolesLicenseCapabilities.java
+++ b/core/src/main/java/com/percolate/sdk/dto/UserRolesLicenseCapabilities.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserRolesLicenseCapabilities implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1031000463223511352L;

--- a/core/src/main/java/com/percolate/sdk/dto/UserRolesLicenseData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/UserRolesLicenseData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserRolesLicenseData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 9122975716120766793L;

--- a/core/src/main/java/com/percolate/sdk/dto/Users.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Users.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Users implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 1691500182715302552L;

--- a/core/src/main/java/com/percolate/sdk/dto/V5Meta.java
+++ b/core/src/main/java/com/percolate/sdk/dto/V5Meta.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class V5Meta implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -3704954110778397943L;

--- a/core/src/main/java/com/percolate/sdk/dto/VideoFormatMetaData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/VideoFormatMetaData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -14,6 +11,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class VideoFormatMetaData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -975272951240201494L;

--- a/core/src/main/java/com/percolate/sdk/dto/Workflow.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Workflow.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Workflow implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -4718949090024226643L;

--- a/core/src/main/java/com/percolate/sdk/dto/WorkflowData.java
+++ b/core/src/main/java/com/percolate/sdk/dto/WorkflowData.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowData implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 6010490237179083126L;

--- a/core/src/main/java/com/percolate/sdk/dto/WorkflowHistory.java
+++ b/core/src/main/java/com/percolate/sdk/dto/WorkflowHistory.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowHistory implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -1674284719017609452L;

--- a/core/src/main/java/com/percolate/sdk/dto/WorkflowHistoryEvent.java
+++ b/core/src/main/java/com/percolate/sdk/dto/WorkflowHistoryEvent.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowHistoryEvent implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = -5572825259266922622L;

--- a/core/src/main/java/com/percolate/sdk/dto/WorkflowHistoryEvents.java
+++ b/core/src/main/java/com/percolate/sdk/dto/WorkflowHistoryEvents.java
@@ -1,6 +1,7 @@
 package com.percolate.sdk.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -8,6 +9,7 @@ import java.util.ArrayList;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowHistoryEvents extends ArrayList<WorkflowHistoryEvent> {
 
     private static final long serialVersionUID = -170628615753569952L;

--- a/core/src/main/java/com/percolate/sdk/dto/WorkflowStep.java
+++ b/core/src/main/java/com/percolate/sdk/dto/WorkflowStep.java
@@ -1,9 +1,6 @@
 package com.percolate.sdk.dto;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.percolate.sdk.interfaces.HasExtraFields;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -15,6 +12,7 @@ import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowStep implements Serializable, HasExtraFields {
 
     private static final long serialVersionUID = 5727730742646755155L;


### PR DESCRIPTION
Added `@JsonInclude(JsonInclude.Include.NON_NULL)` annotation to all DTOs. 

This stops null values from being send in API requests.  Since endpoints act more as PATCH requests, this is a safer strategy.  It also matches how our legacy RoboSpice code would submit data.
