### PR TITLE
add folder_uid option to java-sdk

### DIFF
--- a/api/src/main/java/com/percolate/sdk/api/request/media/MediaListParams.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/media/MediaListParams.java
@@ -37,6 +37,11 @@ public class MediaListParams {
         return this;
     }
 
+    public MediaListParams folderUid(String folderUid) {
+        params.put("folder_uid", folderUid);
+        return this;
+    }
+
     public MediaListParams hideFacets(Boolean hideFacets) {
         params.put("hide_facets", hideFacets);
         return this;


### PR DESCRIPTION
Add `folder_uid` parameter to `v3/media` requests.