### PR TITLE
Add params to preview request

### DIFF
--- a/api/src/main/java/com/percolate/sdk/api/request/preview/PreviewParams.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/preview/PreviewParams.java
@@ -52,6 +52,11 @@ public class PreviewParams {
         return this;
     }
 
+    public PreviewParams interactionId(String interactionId) {
+        params.put("interaction_id", interactionId);
+        return this;
+    }
+
     public PreviewParams ext(LinkedHashMap<String, Object> ext) {
         params.put("ext", ext);
         return this;

--- a/api/src/main/java/com/percolate/sdk/api/request/preview/PreviewParams.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/preview/PreviewParams.java
@@ -57,6 +57,16 @@ public class PreviewParams {
         return this;
     }
 
+    public PreviewParams liveAt(String liveAt) {
+        params.put("live_at", liveAt);
+        return this;
+    }
+
+    public PreviewParams liveAtTimezone(String liveAtTimezone) {
+        params.put("live_at_timezone", liveAtTimezone);
+        return this;
+    }
+
     public PreviewParams ext(LinkedHashMap<String, Object> ext) {
         params.put("ext", ext);
         return this;


### PR DESCRIPTION
Added interaction_id, live_at and live_at_timezone to the `PreviewParams`.