### PR TITLE
Added license settings endpoint

### DIFF
--- a/android/src/main/java/com/percolate/sdk/android/dto/LicensePublishingSettings.java
+++ b/android/src/main/java/com/percolate/sdk/android/dto/LicensePublishingSettings.java
@@ -19,6 +19,7 @@ public class LicensePublishingSettings extends com.percolate.sdk.dto.LicensePubl
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeList(this.topics);
+        dest.writeValue(this.paused);
         dest.writeMap(this.extraFields);
     }
 
@@ -28,6 +29,7 @@ public class LicensePublishingSettings extends com.percolate.sdk.dto.LicensePubl
     protected LicensePublishingSettings(Parcel in) {
         this.topics = new ArrayList<com.percolate.sdk.dto.Topic>();
         in.readList(this.topics, List.class.getClassLoader());
+        this.paused = (Boolean) in.readValue(Boolean.class.getClassLoader());
         this.extraFields = new HashMap<>();
         in.readMap(this.extraFields, HashMap.class.getClassLoader());
     }

--- a/api/src/main/java/com/percolate/sdk/api/PercolateApi.java
+++ b/api/src/main/java/com/percolate/sdk/api/PercolateApi.java
@@ -18,6 +18,7 @@ import com.percolate.sdk.api.request.features.FeaturesRequest;
 import com.percolate.sdk.api.request.followers.FollowersRequest;
 import com.percolate.sdk.api.request.interaction.InteractionRequest;
 import com.percolate.sdk.api.request.license.LicenseRequest;
+import com.percolate.sdk.api.request.license.settings.LicenseSettingsRequest;
 import com.percolate.sdk.api.request.license.users.LicenseUsersRequest;
 import com.percolate.sdk.api.request.licensechannel.LicenseChannelRequest;
 import com.percolate.sdk.api.request.links.LinksRequest;
@@ -321,6 +322,14 @@ public class PercolateApi {
     @SuppressWarnings("unused")
     public InteractionRequest interactions() {
         return new InteractionRequest(this);
+    }
+
+    /**
+     * @return {@link LicenseSettingsRequest} instance.
+     */
+    @SuppressWarnings("unused")
+    public LicenseSettingsRequest licenseSettings() {
+        return new LicenseSettingsRequest(this);
     }
 
     /**

--- a/api/src/main/java/com/percolate/sdk/api/request/license/settings/LicenseSettingsRequest.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/license/settings/LicenseSettingsRequest.java
@@ -1,0 +1,41 @@
+package com.percolate.sdk.api.request.license.settings;
+
+import com.percolate.sdk.api.PercolateApi;
+import com.percolate.sdk.api.utils.RetrofitApiFactory;
+import com.percolate.sdk.dto.LicensePublishingSettings;
+import org.jetbrains.annotations.NotNull;
+import retrofit2.Call;
+
+/**
+ * License settings request proxy.
+ */
+@SuppressWarnings("unused")
+public class LicenseSettingsRequest {
+
+    private LicenseSettingsService service;
+
+    public LicenseSettingsRequest(@NotNull PercolateApi context) {
+        this.service = new RetrofitApiFactory(context).getService(LicenseSettingsService.class);
+    }
+
+    /**
+     * Query license settings endpoint.
+     *
+     * @param id License ID.
+     * @return {@link Call} object.
+     */
+    public Call<LicensePublishingSettings> get(@NotNull final String id) {
+        return service.get(id);
+    }
+
+    /**
+     * Update license settings.
+     *
+     * @param id License ID.
+     * @param body {@link LicensePublishingSettings} object.
+     * @return {@link Call} object.
+     */
+    public Call<LicensePublishingSettings> update(@NotNull final String id, @NotNull final LicensePublishingSettings body) {
+        return service.update(id, body);
+    }
+}

--- a/api/src/main/java/com/percolate/sdk/api/request/license/settings/LicenseSettingsService.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/license/settings/LicenseSettingsService.java
@@ -1,0 +1,21 @@
+package com.percolate.sdk.api.request.license.settings;
+
+import com.percolate.sdk.api.config.Endpoints;
+import com.percolate.sdk.dto.LicensePublishingSettings;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.PUT;
+import retrofit2.http.Path;
+
+/**
+ * Percolate v3/licenses API definition.
+ */
+interface LicenseSettingsService {
+
+    @GET(Endpoints.API_V3_PATH + "/licenses/{id}/settings/publishing")
+    Call<LicensePublishingSettings> get(@Path("id") String id);
+
+    @PUT(Endpoints.API_V3_PATH + "/licenses/{id}/settings/publishing")
+    Call<LicensePublishingSettings> update(@Path("id") String id, @Body LicensePublishingSettings body);
+}

--- a/api/src/test/fixtures/api/v3/licenses/123/settings/publishing/GET.json
+++ b/api/src/test/fixtures/api/v3/licenses/123/settings/publishing/GET.json
@@ -1,0 +1,25 @@
+{
+  "guardrails": {},
+  "scheduling": {
+    "enabled": false,
+    "daily_frequency": null,
+    "from_hour": null,
+    "days": null,
+    "to_hour": null
+  },
+  "approvee_ids": [],
+  "targeting_presets": [],
+  "tags": [],
+  "platform_uids": [],
+  "preferred_term_uids": [],
+  "tag_ids": [],
+  "paused": false,
+  "platforms": [],
+  "image_editor_tools": [],
+  "services": [],
+  "crops": [],
+  "external_media_rate_limit": 1000,
+  "publishing": {
+    "reference_source": true
+  }
+}

--- a/api/src/test/fixtures/api/v3/licenses/123/settings/publishing/PUT.json
+++ b/api/src/test/fixtures/api/v3/licenses/123/settings/publishing/PUT.json
@@ -1,0 +1,25 @@
+{
+  "guardrails": {},
+  "scheduling": {
+    "enabled": false,
+    "daily_frequency": null,
+    "from_hour": null,
+    "days": null,
+    "to_hour": null
+  },
+  "approvee_ids": [],
+  "targeting_presets": [],
+  "tags": [],
+  "platform_uids": [],
+  "preferred_term_uids": [],
+  "tag_ids": [],
+  "paused": true,
+  "platforms": [],
+  "image_editor_tools": [],
+  "services": [],
+  "crops": [],
+  "external_media_rate_limit": 1000,
+  "publishing": {
+    "reference_source": true
+  }
+}

--- a/api/src/test/java/com/percolate/sdk/api/BaseApiTest.kt
+++ b/api/src/test/java/com/percolate/sdk/api/BaseApiTest.kt
@@ -7,7 +7,7 @@ package com.percolate.sdk.api
  */
 open class BaseApiTest {
 
-    var percolateApi : PercolateApi;
+    var percolateApi : PercolateApi
 
     constructor() {
         percolateApi = PercolateApi("")

--- a/api/src/test/java/com/percolate/sdk/api/request/license/settings/LicenseSettingsRequestTest.kt
+++ b/api/src/test/java/com/percolate/sdk/api/request/license/settings/LicenseSettingsRequestTest.kt
@@ -1,0 +1,33 @@
+package com.percolate.sdk.api.request.license.users
+
+import com.percolate.sdk.api.BaseApiTest
+import com.percolate.sdk.dto.LicensePublishingSettings
+import org.junit.Assert
+import org.junit.Test
+
+class LicenseSettingsRequestTest : BaseApiTest() {
+
+    @Test
+    fun testGet() {
+        val licenseSettings = percolateApi
+                .licenseSettings()
+                .get("123")
+                .execute()
+                .body()
+
+        Assert.assertNotNull(licenseSettings)
+        Assert.assertFalse(licenseSettings.paused)
+    }
+
+    @Test
+    fun testUpdate() {
+        val licenseSettings = percolateApi
+                .licenseSettings()
+                .update("123", LicensePublishingSettings())
+                .execute()
+                .body()
+
+        Assert.assertNotNull(licenseSettings)
+        Assert.assertTrue(licenseSettings.paused)
+    }
+}

--- a/core/src/main/java/com/percolate/sdk/dto/LicensePublishingSettings.java
+++ b/core/src/main/java/com/percolate/sdk/dto/LicensePublishingSettings.java
@@ -15,7 +15,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class LicensePublishingSettings implements Serializable, HasExtraFields {
 
-    private static final long serialVersionUID = -5154375915441246126L;
+    private static final long serialVersionUID = -7497352074904109845L;
 
     /* Everything available in the JSON:
          * guardrails
@@ -35,6 +35,9 @@ public class LicensePublishingSettings implements Serializable, HasExtraFields {
     @JsonProperty("tags")
     protected List<Topic> topics;
 
+    @JsonProperty("paused")
+    protected Boolean paused;
+
     @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
@@ -49,6 +52,14 @@ public class LicensePublishingSettings implements Serializable, HasExtraFields {
 
     public void setTopics(List<Topic> topics) {
         this.topics = topics;
+    }
+
+    public Boolean getPaused() {
+        return paused;
+    }
+
+    public void setPaused(Boolean paused) {
+        this.paused = paused;
     }
 
     @Override

--- a/rxjava/src/main/java/com/percolate/sdk/rxjava/PercolateApiRx.java
+++ b/rxjava/src/main/java/com/percolate/sdk/rxjava/PercolateApiRx.java
@@ -21,6 +21,7 @@ import com.percolate.sdk.rxjava.request.features.FeaturesRequestRx;
 import com.percolate.sdk.rxjava.request.followers.FollowersRequestRx;
 import com.percolate.sdk.rxjava.request.interaction.InteractionRequestRx;
 import com.percolate.sdk.rxjava.request.license.LicenseRequestRx;
+import com.percolate.sdk.rxjava.request.license.settings.LicenseSettingsRequestRx;
 import com.percolate.sdk.rxjava.request.license.users.LicenseUsersRequestRx;
 import com.percolate.sdk.rxjava.request.licensechannel.LicenseChannelRequestRx;
 import com.percolate.sdk.rxjava.request.links.LinksRequestRx;
@@ -249,6 +250,14 @@ public class PercolateApiRx extends PercolateApi {
     @SuppressWarnings("unused")
     public InteractionRequestRx interactionsRx() {
         return new InteractionRequestRx(this);
+    }
+
+    /**
+     * @return {@link LicenseSettingsRequestRx} instance.
+     */
+    @SuppressWarnings("unused")
+    public LicenseSettingsRequestRx licenseSettingsRx() {
+        return new LicenseSettingsRequestRx(this);
     }
 
     /**

--- a/rxjava/src/main/java/com/percolate/sdk/rxjava/request/license/settings/LicenseSettingsRequestRx.java
+++ b/rxjava/src/main/java/com/percolate/sdk/rxjava/request/license/settings/LicenseSettingsRequestRx.java
@@ -1,0 +1,41 @@
+package com.percolate.sdk.rxjava.request.license.settings;
+
+import com.percolate.sdk.api.PercolateApi;
+import com.percolate.sdk.api.utils.RetrofitApiFactory;
+import com.percolate.sdk.dto.LicensePublishingSettings;
+import org.jetbrains.annotations.NotNull;
+import rx.Observable;
+
+/**
+ * License settings request proxy.
+ */
+@SuppressWarnings("unused")
+public class LicenseSettingsRequestRx {
+
+    private LicenseSettingsServiceRx service;
+
+    public LicenseSettingsRequestRx(@NotNull PercolateApi context) {
+        this.service = new RetrofitApiFactory(context).getService(LicenseSettingsServiceRx.class);
+    }
+
+    /**
+     * Query license settings endpoint.
+     *
+     * @param id License ID.
+     * @return {@link Observable} object.
+     */
+    public Observable<LicensePublishingSettings> get(@NotNull final String id) {
+        return service.get(id);
+    }
+
+    /**
+     * Update license settings.
+     *
+     * @param id License ID.
+     * @param body {@link LicensePublishingSettings} object.
+     * @return {@link Observable} object.
+     */
+    public Observable<LicensePublishingSettings> update(@NotNull final String id, @NotNull final LicensePublishingSettings body) {
+        return service.update(id, body);
+    }
+}

--- a/rxjava/src/main/java/com/percolate/sdk/rxjava/request/license/settings/LicenseSettingsServiceRx.java
+++ b/rxjava/src/main/java/com/percolate/sdk/rxjava/request/license/settings/LicenseSettingsServiceRx.java
@@ -1,0 +1,21 @@
+package com.percolate.sdk.rxjava.request.license.settings;
+
+import com.percolate.sdk.api.config.Endpoints;
+import com.percolate.sdk.dto.LicensePublishingSettings;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.PUT;
+import retrofit2.http.Path;
+import rx.Observable;
+
+/**
+ * Percolate v3/licenses API definition.
+ */
+interface LicenseSettingsServiceRx {
+
+    @GET(Endpoints.API_V3_PATH + "/licenses/{id}/settings/publishing")
+    Observable<LicensePublishingSettings> get(@Path("id") String id);
+
+    @PUT(Endpoints.API_V3_PATH + "/licenses/{id}/settings/publishing")
+    Observable<LicensePublishingSettings> update(@Path("id") String id, @Body LicensePublishingSettings body);
+}


### PR DESCRIPTION
New `license/<id>/settings/publishing` endpoint used to get publishing status.