### PR TITLE
Add metadata fields to Post objects

### DIFF
--- a/android/src/main/java/com/percolate/sdk/android/dto/Post.java
+++ b/android/src/main/java/com/percolate/sdk/android/dto/Post.java
@@ -55,6 +55,7 @@ public class Post extends com.percolate.sdk.dto.Post implements Parcelable {
         dest.writeString(this.errorId);
         dest.writeValue(this.approvalPoolId);
         dest.writeList(this.facebookMentions);
+        dest.writeList(this.metadata);
         dest.writeMap(this.extraFields);
         dest.writeMap(this.extraFields);
     }
@@ -94,8 +95,10 @@ public class Post extends com.percolate.sdk.dto.Post implements Parcelable {
         this.referenceXId = in.readString();
         this.errorId = in.readString();
         this.approvalPoolId = (Long) in.readValue(Long.class.getClassLoader());
-        this.facebookMentions = new ArrayList<FacebookMentionData>();
+        this.facebookMentions = new ArrayList<>();
         in.readList(this.facebookMentions, List.class.getClassLoader());
+        this.metadata= new ArrayList<>();
+        in.readList(this.metadata, List.class.getClassLoader());
         this.extraFields = new HashMap<>();
         in.readMap(this.extraFields, HashMap.class.getClassLoader());
     }

--- a/android/src/main/java/com/percolate/sdk/android/dto/PostV5Data.java
+++ b/android/src/main/java/com/percolate/sdk/android/dto/PostV5Data.java
@@ -46,6 +46,7 @@ public class PostV5Data extends com.percolate.sdk.dto.PostV5Data implements Parc
         dest.writeStringList(this.termIds);
         dest.writeStringList(this.originIds);
         dest.writeStringList(this.linkIds);
+        dest.writeList(this.metadata);
         dest.writeString(this.createdAt);
         dest.writeString(this.updatedAt);
         dest.writeMap(this.ext);
@@ -83,6 +84,7 @@ public class PostV5Data extends com.percolate.sdk.dto.PostV5Data implements Parc
         this.termIds = other.getTermIds();
         this.originIds = other.getOriginIds();
         this.linkIds = other.getLinkIds();
+        this.metadata = other.getMetadata();
         this.createdAt = other.getCreatedAt();
         this.updatedAt = other.getUpdatedAt();
         this.ext = other.getExt();
@@ -118,6 +120,8 @@ public class PostV5Data extends com.percolate.sdk.dto.PostV5Data implements Parc
         this.termIds = in.createStringArrayList();
         this.originIds = in.createStringArrayList();
         this.linkIds = in.createStringArrayList();
+        this.metadata= new ArrayList<>();
+        in.readList(this.metadata, List.class.getClassLoader());
         this.createdAt = in.readString();
         this.updatedAt = in.readString();
         this.ext = new LinkedHashMap<>();

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     compile 'org.jetbrains:annotations-java5:15.0'
 
     // Retrofit
-    compile 'com.squareup.retrofit2:retrofit:2.0.2'
-    compile 'com.squareup.retrofit2:converter-jackson:2.0.2'
-    compile 'com.squareup.retrofit2:adapter-rxjava:2.0.2'
+    compile "com.squareup.retrofit2:retrofit:${retrofitVersion}"
+    compile "com.squareup.retrofit2:converter-jackson:${retrofitVersion}"
+    compile "com.squareup.retrofit2:adapter-rxjava:${retrofitVersion}"
 }

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -71,6 +71,6 @@ dependencies {
     compile 'org.jetbrains:annotations-java5:15.0'
 
     // Retrofit
-    compile 'com.squareup.retrofit2:retrofit:2.0.0'
-    compile 'com.squareup.retrofit2:converter-jackson:2.0.0'
+    compile "com.squareup.retrofit2:retrofit:${retrofitVersion}"
+    compile "com.squareup.retrofit2:converter-jackson:${retrofitVersion}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,4 +17,5 @@ ext {
     buildToolsVersion = "23.0.2"
     minSdkVersion = 16
     targetSdkVersion = 23
+    retrofitVersion = "2.1.0"
 }

--- a/core/src/main/java/com/percolate/sdk/dto/Post.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Post.java
@@ -107,6 +107,9 @@ public class Post implements Serializable, HasExtraFields {
     @JsonProperty("facebook_mentions")
     protected List<FacebookMentionData> facebookMentions;
 
+    @JsonProperty("metadata")
+    protected List<MetadataItem> metadata;
+
     @JsonIgnore
     protected Map<String, Object> extraFields = new HashMap<>();
 
@@ -321,6 +324,14 @@ public class Post implements Serializable, HasExtraFields {
 
     public void setFacebookMentions(List<FacebookMentionData> facebookMentions) {
         this.facebookMentions = facebookMentions;
+    }
+
+    public List<MetadataItem> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(List<MetadataItem> metadata) {
+        this.metadata = metadata;
     }
 
     @Override

--- a/core/src/main/java/com/percolate/sdk/dto/PostV5Data.java
+++ b/core/src/main/java/com/percolate/sdk/dto/PostV5Data.java
@@ -109,6 +109,9 @@ public class PostV5Data implements Serializable, HasExtraFields {
     @JsonProperty("link_ids")
     protected List<String> linkIds;
 
+    @JsonProperty("metadata")
+    protected List<MetadataItem> metadata;
+
     @JsonProperty("created_at")
     protected String createdAt;
 
@@ -292,6 +295,14 @@ public class PostV5Data implements Serializable, HasExtraFields {
 
     public void setLinkIds(List<String> linkIds) {
         this.linkIds = linkIds;
+    }
+
+    public List<MetadataItem> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(List<MetadataItem> metadata) {
+        this.metadata = metadata;
     }
 
     public String getCreatedAt() {

--- a/python-bridge/build.gradle
+++ b/python-bridge/build.gradle
@@ -68,6 +68,6 @@ dependencies {
     compile 'org.jetbrains:annotations-java5:15.0'
 
     // Retrofit
-    compile 'com.squareup.retrofit2:retrofit:2.0.0'
-    compile 'com.squareup.retrofit2:converter-jackson:2.0.0'
+    compile "com.squareup.retrofit2:retrofit:${retrofitVersion}"
+    compile "com.squareup.retrofit2:converter-jackson:${retrofitVersion}"
 }


### PR DESCRIPTION
Post object endpoints now support sending `metadata` as part of `POST` and `PUT` requests.  This PR adds `metadata` fields to Post DTO objects.