### PR TITLE
Update terms endpoint to support taxonomies

### DIFF
--- a/android/src/main/java/com/percolate/sdk/android/dto/Term.java
+++ b/android/src/main/java/com/percolate/sdk/android/dto/Term.java
@@ -20,6 +20,11 @@ public class Term extends com.percolate.sdk.dto.Term implements Parcelable {
         dest.writeString(this.name);
         dest.writeString(this.namespace);
         dest.writeString(this.scopeId);
+        dest.writeString(this.parentId);
+        dest.writeString(this.taxonomyId);
+        dest.writeValue(this.childCount);
+        dest.writeStringList(this.pathIds);
+        dest.writeString(this.createdAt);
         dest.writeString(this.updatedAt);
         dest.writeMap(this.extraFields);
     }
@@ -32,6 +37,11 @@ public class Term extends com.percolate.sdk.dto.Term implements Parcelable {
         this.name = in.readString();
         this.namespace = in.readString();
         this.scopeId = in.readString();
+        this.parentId = in.readString();
+        this.taxonomyId = in.readString();
+        this.childCount = (Long) in.readValue(Long.class.getClassLoader());
+        this.pathIds = in.createStringArrayList();
+        this.createdAt = in.readString();
         this.updatedAt = in.readString();
         this.extraFields = new HashMap<>();
         in.readMap(this.extraFields, HashMap.class.getClassLoader());

--- a/api/src/main/java/com/percolate/sdk/api/request/terms/TermsParams.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/terms/TermsParams.java
@@ -1,5 +1,7 @@
 package com.percolate.sdk.api.request.terms;
 
+import com.percolate.sdk.enums.TermIncludeTypes;
+import com.percolate.sdk.enums.TermModeTypes;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
@@ -31,6 +33,42 @@ public class TermsParams {
         params.put("search", search);
         return this;
     }
+
+    public TermsParams parentIds(List<String> parentIds) {
+        params.put("parent_ids", StringUtils.join(parentIds, ","));
+        return this;
+    }
+
+    public TermsParams include(List<TermIncludeTypes> include) {
+        params.put("include", StringUtils.join(include, ",").toLowerCase());
+        return this;
+    }
+
+    public TermsParams mode(TermModeTypes mode){
+        params.put("mode", mode.toString().toLowerCase());
+        return this;
+    }
+
+    public TermsParams depth(String depth){
+        params.put("depth", depth);
+        return this;
+    }
+
+    public TermsParams namespace(String namespace){
+        params.put("namespace", namespace);
+        return this;
+    }
+
+    public TermsParams limit(String limit){
+        params.put("limit", limit);
+        return this;
+    }
+
+    public TermsParams offset(String offset){
+        params.put("offset", offset);
+        return this;
+    }
+
 
     public Map<String, Object> getParams() {
         return params;

--- a/core/src/main/java/com/percolate/sdk/dto/Term.java
+++ b/core/src/main/java/com/percolate/sdk/dto/Term.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("UnusedDeclaration")
@@ -20,16 +21,31 @@ public class Term implements Serializable, HasExtraFields {
     private static final long serialVersionUID = 3098198274190964473L;
 
     @JsonProperty("id")
-    protected String id;   // term id
+    protected String id;
 
     @JsonProperty("name")
-    protected String name;  // tag name
+    protected String name;
 
     @JsonProperty("namespace")
-    protected String namespace;  // the namespace the term belongs to
+    protected String namespace;
 
     @JsonProperty("scope_id")
-    protected String scopeId;  // an ID of the owner
+    protected String scopeId;
+
+    @JsonProperty("parent_id")
+    protected String parentId;
+
+    @JsonProperty("taxonomy_id")
+    protected String taxonomyId;
+
+    @JsonProperty("child_count")
+    protected Long childCount;
+
+    @JsonProperty("path_ids")
+    protected List<String> pathIds;
+
+    @JsonProperty("created_at")
+    protected String createdAt;
 
     @JsonProperty("update_at")
     protected String updatedAt;
@@ -71,12 +87,12 @@ public class Term implements Serializable, HasExtraFields {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }
 
-    public String getUid() {
+    public String getId() {
         return id;
     }
 
-    public void setUid(String uid) {
-        this.id = uid;
+    public void setId(String id) {
+        this.id = id;
     }
 
     public String getName() {
@@ -101,6 +117,46 @@ public class Term implements Serializable, HasExtraFields {
 
     public void setScopeId(String scopeId) {
         this.scopeId = scopeId;
+    }
+
+    public String getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
+    }
+
+    public String getTaxonomyId() {
+        return taxonomyId;
+    }
+
+    public void setTaxonomyId(String taxonomyId) {
+        this.taxonomyId = taxonomyId;
+    }
+
+    public Long getChildCount() {
+        return childCount;
+    }
+
+    public void setChildCount(Long childCount) {
+        this.childCount = childCount;
+    }
+
+    public List<String> getPathIds() {
+        return pathIds;
+    }
+
+    public void setPathIds(List<String> pathIds) {
+        this.pathIds = pathIds;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
     }
 
     public String getUpdatedAt() {

--- a/core/src/main/java/com/percolate/sdk/enums/TermIncludeTypes.java
+++ b/core/src/main/java/com/percolate/sdk/enums/TermIncludeTypes.java
@@ -1,0 +1,8 @@
+package com.percolate.sdk.enums;
+
+/**
+ * Valid values for Term includes
+ */
+public enum TermIncludeTypes {
+    PATH_ID
+}

--- a/core/src/main/java/com/percolate/sdk/enums/TermModeTypes.java
+++ b/core/src/main/java/com/percolate/sdk/enums/TermModeTypes.java
@@ -1,0 +1,9 @@
+package com.percolate.sdk.enums;
+
+/**
+ * Valid values for terms {@code mode} parameter.
+ */
+public enum TermModeTypes {
+    REGULAR,
+    TAXONOMY
+}


### PR DESCRIPTION
Passing `mode=taxonomy` will cause the `v5/terms` endpoint to function on percolate taxonomy data.