### PR TITLE
Use Trailing Slash for PAM Resource Endpoints

### DIFF
--- a/api/src/main/java/com/percolate/sdk/api/request/assets/AssetsService.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/assets/AssetsService.java
@@ -20,7 +20,7 @@ interface AssetsService {
     @GET(Endpoints.API_V5_PATH + "/asset/{asset_id}")
     Call<SingleAsset> get(@Path("asset_id") String assetId, @QueryMap Map<String, Object> params);
 
-    @GET(Endpoints.API_V5_PATH + "/asset")
+    @GET(Endpoints.API_V5_PATH + "/asset/")
     Call<Assets> list(@QueryMap Map<String, Object> params);
 
     @Streaming

--- a/api/src/main/java/com/percolate/sdk/api/request/folders/FoldersService.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/folders/FoldersService.java
@@ -18,6 +18,6 @@ interface FoldersService {
     @GET(Endpoints.API_V5_PATH + "/folder/{folder_id}")
     Call<SingleFolder> get(@Path("folder_id") String folderId, @QueryMap Map<String, Object> params);
 
-    @GET(Endpoints.API_V5_PATH + "/folder")
+    @GET(Endpoints.API_V5_PATH + "/folder/")
     Call<Folders> list(@QueryMap Map<String, Object> params);
 }

--- a/api/src/main/java/com/percolate/sdk/api/request/variants/VariantsService.java
+++ b/api/src/main/java/com/percolate/sdk/api/request/variants/VariantsService.java
@@ -20,7 +20,7 @@ interface VariantsService {
     @GET(Endpoints.API_V5_PATH + "/variant/{variant_id}")
     Call<SingleVariant> get(@Path("variant_id") String variantId, @QueryMap Map<String, Object> params);
 
-    @GET(Endpoints.API_V5_PATH + "/variant")
+    @GET(Endpoints.API_V5_PATH + "/variant/")
     Call<Variants> list(@QueryMap Map<String, Object> params);
 
     @Streaming


### PR DESCRIPTION
The following resource endpoints *must* have a trailing slash:

- `/api/v5/asset/`
- `/api/v5/folder/`
- `/api/v5/variant/`